### PR TITLE
do not allow patients with warning issues without confirmation to go into matching run (before now it was that errors are not allowed to go into the matching run)

### DIFF
--- a/tests/web/public_api/test_public_patient_upload_data_validation.py
+++ b/tests/web/public_api/test_public_patient_upload_data_validation.py
@@ -40,8 +40,8 @@ class TestMatchingApi(DbTests):
         self._check_response(res, 200)
         txm_event = get_txm_event_complete(txm_event.db_id)
         self.assertEqual(txm_event.name, txm_event.name)
-        self.assertEqual(3, len(txm_event.active_and_valid_recipients_dict))
-        self.assertEqual(4, len(txm_event.active_and_valid_donors_dict))
+        self.assertEqual(2, len(txm_event.active_and_valid_recipients_dict))
+        self.assertEqual(3, len(txm_event.active_and_valid_donors_dict))
         self.assertEqual(3, res.json['recipients_uploaded'])
         self.assertEqual(4, res.json['donors_uploaded'])
 

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -11,8 +11,7 @@ from tests.test_utilities.hla_preparation_utils import (create_antibodies,
 from tests.test_utilities.prepare_app_for_tests import DbTests
 from txmatching.database.services.txm_event_service import \
     get_txm_event_complete
-from txmatching.database.sql_alchemy_schema import (ConfigModel,
-                                                    DonorModel,
+from txmatching.database.sql_alchemy_schema import (ConfigModel, DonorModel,
                                                     ParsingIssueModel,
                                                     RecipientModel,
                                                     UploadedFileModel)
@@ -20,7 +19,8 @@ from txmatching.patients.patient import DonorType, RecipientRequirements
 from txmatching.utils.blood_groups import BloodGroup
 from txmatching.utils.enums import Sex
 from txmatching.utils.get_absolute_path import get_absolute_path
-from txmatching.utils.hla_system.hla_transformations.parsing_issue_detail import ParsingIssueDetail
+from txmatching.utils.hla_system.hla_transformations.parsing_issue_detail import \
+    ParsingIssueDetail
 from txmatching.web import API_VERSION, PATIENT_NAMESPACE, TXM_EVENT_NAMESPACE
 
 
@@ -619,7 +619,6 @@ class TestPatientService(DbTests):
             self.assertEqual(None, warning_issue.confirmed_by)
             self.assertEqual(None, error_issue.confirmed_by)
 
-            # TODO https://github.com/mild-blue/txmatching/issues/860
             txm_event = get_txm_event_complete(txm_event_db_id)
             self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -187,7 +187,7 @@ class TestPatientService(DbTests):
                             'mfi': 2000,
                             'name': 'test',
                             'cutoff': 2000
-                        }],
+                    }],
                 },
                 'country_code': 'CZE'
             }
@@ -612,16 +612,16 @@ class TestPatientService(DbTests):
             self.assertEqual(200, res.status_code)
 
             warning_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
-                    ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
+                ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
             error_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
-                    ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.MORE_THAN_TWO_HLA_CODES_PER_GROUP)).first()
+                ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.MORE_THAN_TWO_HLA_CODES_PER_GROUP)).first()
 
             self.assertEqual(None, warning_issue.confirmed_by)
             self.assertEqual(None, error_issue.confirmed_by)
 
             # TODO https://github.com/mild-blue/txmatching/issues/860
-            # txm_event = get_txm_event_complete(txm_event_db_id)
-            # self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
+            txm_event = get_txm_event_complete(txm_event_db_id)
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',
@@ -682,7 +682,7 @@ class TestPatientService(DbTests):
             self.assertEqual(200, res.status_code)
 
             warning_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
-                    ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
+                ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
             self.assertEqual(None, warning_issue.confirmed_by)
 
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -618,7 +618,6 @@ class TestPatientService(DbTests):
             txm_event = get_txm_event_complete(txm_event_db_id)
             self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 
-
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',
                              headers=self.auth_headers)
@@ -634,7 +633,7 @@ class TestPatientService(DbTests):
                              headers=self.auth_headers)
             self.assertEqual(406, res.status_code)
 
-    def  test_confirming_error_issue(self):
+    def test_confirming_error_issue(self):
         txm_event_db_id = self.fill_db_with_patients(
             get_absolute_path(PATIENT_DATA_OBFUSCATED))
         recipient_db_id = 10
@@ -686,7 +685,7 @@ class TestPatientService(DbTests):
                              headers=self.auth_headers)
             self.assertEqual(400, res.status_code)
 
-            self.assertEqual(None, error_issue.confirmed_by) 
+            self.assertEqual(None, error_issue.confirmed_by)
 
     def test_unconfirming_warning_issue(self):
         txm_event_db_id = self.fill_db_with_patients(
@@ -730,7 +729,6 @@ class TestPatientService(DbTests):
             warning_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
                 ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
             self.assertEqual(None, warning_issue.confirmed_by)
-
 
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -586,7 +586,6 @@ class TestPatientService(DbTests):
                 'hla_typing': {
                     'hla_types_list': [{'raw_code': 'A*01:02'},
                                        {'raw_code': 'A*01:02'},
-                                       {'raw_code': 'A*01:02'},
                                        {'raw_code': 'BW4'},
                                        {'raw_code': 'B7'},
                                        {'raw_code': 'DR11'}]
@@ -613,18 +612,20 @@ class TestPatientService(DbTests):
 
             warning_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
                 ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
-            error_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
-                ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.MORE_THAN_TWO_HLA_CODES_PER_GROUP)).first()
 
             self.assertEqual(None, warning_issue.confirmed_by)
-            self.assertEqual(None, error_issue.confirmed_by)
 
             txm_event = get_txm_event_complete(txm_event_db_id)
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
+
 
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',
                              headers=self.auth_headers)
             self.assertEqual(200, res.status_code)
+
+            txm_event = get_txm_event_complete(txm_event_db_id)
+            self.assertTrue(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 
             self.assertNotEqual(None, warning_issue.confirmed_by)
 
@@ -633,14 +634,59 @@ class TestPatientService(DbTests):
                              headers=self.auth_headers)
             self.assertEqual(406, res.status_code)
 
+    def  test_confirming_error_issue(self):
+        txm_event_db_id = self.fill_db_with_patients(
+            get_absolute_path(PATIENT_DATA_OBFUSCATED))
+        recipient_db_id = 10
+        etag = RecipientModel.query.get(recipient_db_id).etag
+
+        with self.app.test_client() as client:
+            json_data = {
+                'db_id': recipient_db_id,
+                'etag': etag,
+                'blood_group': 'A',
+                'hla_typing': {
+                    'hla_types_list': [{'raw_code': 'A*01:02'},
+                                       {'raw_code': 'A*01:02'},
+                                       {'raw_code': 'A*01:02'},
+                                       {'raw_code': 'BW4'},
+                                       {'raw_code': 'B7'},
+                                       {'raw_code': 'DR11'}]
+                },
+                'sex': 'M',
+                'height': 200,
+                'weight': 100,
+                'year_of_birth': 1990,
+                'acceptable_blood_groups': ['A', 'B', 'AB'],
+                'hla_antibodies': {
+                    'hla_antibodies_list': []
+                },
+                'recipient_requirements': {
+                    'require_better_match_in_compatibility_index': True,
+                    'require_better_match_in_compatibility_index_or_blood_group': True,
+                    'require_compatible_blood_group': True
+                },
+                'cutoff': 42
+            }
+            res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
+                             f'{PATIENT_NAMESPACE}/recipient',
+                             headers=self.auth_headers, json=json_data)
+            self.assertEqual(200, res.status_code)
+
+            error_issue = ParsingIssueModel.query.filter(and_(ParsingIssueModel.recipient_id == recipient_db_id), (
+                ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.MORE_THAN_TWO_HLA_CODES_PER_GROUP)).first()
+
+            self.assertEqual(None, error_issue.confirmed_by)
+
+            txm_event = get_txm_event_complete(txm_event_db_id)
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
+
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{error_issue.id}',
                              headers=self.auth_headers)
             self.assertEqual(400, res.status_code)
 
-            self.assertEqual(None, error_issue.confirmed_by)
-            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
-            
+            self.assertEqual(None, error_issue.confirmed_by) 
 
     def test_unconfirming_warning_issue(self):
         txm_event_db_id = self.fill_db_with_patients(
@@ -685,10 +731,14 @@ class TestPatientService(DbTests):
                 ParsingIssueModel.parsing_issue_detail == ParsingIssueDetail.IRRELEVANT_CODE)).first()
             self.assertEqual(None, warning_issue.confirmed_by)
 
+
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',
                              headers=self.auth_headers)
             self.assertEqual(200, res.status_code)
+
+            txm_event = get_txm_event_complete(txm_event_db_id)
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 
             self.assertNotEqual(None, warning_issue.confirmed_by)
 
@@ -703,3 +753,5 @@ class TestPatientService(DbTests):
                              f'{PATIENT_NAMESPACE}/unconfirm-warning/{warning_issue.id}',
                              headers=self.auth_headers)
             self.assertEqual(406, res.status_code)
+
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -620,7 +620,6 @@ class TestPatientService(DbTests):
             self.assertEqual(None, error_issue.confirmed_by)
 
             txm_event = get_txm_event_complete(txm_event_db_id)
-            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
 
             res = client.put(f'{API_VERSION}/{TXM_EVENT_NAMESPACE}/{txm_event_db_id}/'
                              f'{PATIENT_NAMESPACE}/confirm-warning/{warning_issue.id}',
@@ -640,6 +639,8 @@ class TestPatientService(DbTests):
             self.assertEqual(400, res.status_code)
 
             self.assertEqual(None, error_issue.confirmed_by)
+            self.assertFalse(recipient_db_id in txm_event.active_and_valid_recipients_dict)
+            
 
     def test_unconfirming_warning_issue(self):
         txm_event_db_id = self.fill_db_with_patients(

--- a/txmatching/database/services/pairing_result_service.py
+++ b/txmatching/database/services/pairing_result_service.py
@@ -27,10 +27,10 @@ def get_pairing_result_comparable_to_config_or_solve(
         txm_event: TxmEvent
 ) -> PairingResultModel:
     maybe_pairing_result_model = get_pairing_result_comparable_to_config(configuration, txm_event)
-    if maybe_pairing_result_model is not None:
-        return maybe_pairing_result_model
-    else:
-        return solve_from_configuration_and_save(configuration, txm_event)
+    # if maybe_pairing_result_model is not None:
+    #     return maybe_pairing_result_model
+    # else:
+    return solve_from_configuration_and_save(configuration, txm_event)
 
 
 def get_pairing_result_comparable_to_config(

--- a/txmatching/database/services/pairing_result_service.py
+++ b/txmatching/database/services/pairing_result_service.py
@@ -27,10 +27,10 @@ def get_pairing_result_comparable_to_config_or_solve(
         txm_event: TxmEvent
 ) -> PairingResultModel:
     maybe_pairing_result_model = get_pairing_result_comparable_to_config(configuration, txm_event)
-    # if maybe_pairing_result_model is not None:
-    #     return maybe_pairing_result_model
-    # else:
-    return solve_from_configuration_and_save(configuration, txm_event)
+    if maybe_pairing_result_model is not None:
+        return maybe_pairing_result_model
+    else:
+        return solve_from_configuration_and_save(configuration, txm_event)
 
 
 def get_pairing_result_comparable_to_config(

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -153,7 +153,7 @@ class TxmEvent(TxmEventBase):
         (
             self.active_and_valid_donors_dict,
             self.active_and_valid_recipients_dict,
-        ) = _filter_patients_that_dont_have_parsing_errors_and_have_confirmed_warnings(all_donors, all_recipients)
+        ) = _filter_patients_that_dont_have_parsing_errors_or_have_confirmed_warnings(all_donors, all_recipients)
 
 
 def calculate_cutoff(hla_antibodies_raw_list: List[HLAAntibodyRaw]) -> int:
@@ -193,20 +193,20 @@ def is_number_of_previous_transplants_valid(previous_transplants: int):
             f'Invalid recipient number of previous transplants {previous_transplants}.')
 
 
-def _filter_patients_that_dont_have_parsing_errors_and_have_confirmed_warnings(
+def _filter_patients_that_dont_have_parsing_errors_or_have_confirmed_warnings(
         donors: List[Donor], recipients: List[Recipient]
 ) -> Tuple[Dict[DonorDbId, Donor], Dict[RecipientDbId, Recipient]]:
     exclude_donors_ids = set()
     exclude_recipients_ids = set()
 
     for patient in donors:
-        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or 
-            _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
+        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or
+                _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
             exclude_donors_ids.add(patient.db_id)
 
     for patient in recipients:
-        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or 
-            _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
+        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or
+                _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
             for donor_id in patient.related_donors_db_ids:
                 exclude_donors_ids.add(donor_id)
             exclude_recipients_ids.add(patient.db_id)

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -193,7 +193,7 @@ def is_number_of_previous_transplants_valid(previous_transplants: int):
             f'Invalid recipient number of previous transplants {previous_transplants}.')
 
 
-def _filter_patients_that_dont_have_parsing_errors_or_have_confirmed_warnings(
+def _filter_patients_that_dont_have_parsing_errors_or_unconfirmed_warnings(
         donors: List[Donor], recipients: List[Recipient]
 ) -> Tuple[Dict[DonorDbId, Donor], Dict[RecipientDbId, Recipient]]:
     exclude_donors_ids = set()

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional, Tuple
 
 from txmatching.auth.exceptions import InvalidArgumentException
 from txmatching.data_transfer_objects.hla.parsing_issue_dto import ParsingIssue
-# from txmatching.database.sql_alchemy_schema import ParsingIssueModel
 from txmatching.patients.hla_model import HLAAntibodies, HLAAntibodyRaw
 from txmatching.patients.patient_parameters import (Centimeters, Kilograms,
                                                     PatientParameters)
@@ -154,7 +153,7 @@ class TxmEvent(TxmEventBase):
         (
             self.active_and_valid_donors_dict,
             self.active_and_valid_recipients_dict,
-        ) = _filter_patients_that_dont_have_parsing_errors_or_they_are_confirmed(all_donors, all_recipients)
+        ) = _filter_patients_that_dont_have_parsing_errors_and_have_confirmed_warnings(all_donors, all_recipients)
 
         # here has to be checked if the donor with issue is confirmed
         # if it is confirmed, the donor stays in the list if not, it is removed
@@ -197,7 +196,7 @@ def is_number_of_previous_transplants_valid(previous_transplants: int):
             f'Invalid recipient number of previous transplants {previous_transplants}.')
 
 
-def _filter_patients_that_dont_have_parsing_errors_or_they_are_confirmed(
+def _filter_patients_that_dont_have_parsing_errors_and_have_confirmed_warnings(
         donors: List[Donor], recipients: List[Recipient]
 ) -> Tuple[Dict[DonorDbId, Donor], Dict[RecipientDbId, Recipient]]:
     exclude_donors_ids = set()

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -200,19 +200,15 @@ def _filter_patients_that_dont_have_parsing_errors_and_have_confirmed_warnings(
     exclude_recipients_ids = set()
 
     for patient in donors:
-        if _parsing_issue_list_contains_errors(patient.parsing_issues):
-            exclude_donors_ids.add(patient.db_id)
-
-        if _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues):
+        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or 
+            _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
             exclude_donors_ids.add(patient.db_id)
 
     for patient in recipients:
-        if _parsing_issue_list_contains_errors(patient.parsing_issues):
+        if (_parsing_issue_list_contains_errors(patient.parsing_issues) or 
+            _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues)):
             for donor_id in patient.related_donors_db_ids:
                 exclude_donors_ids.add(donor_id)
-            exclude_recipients_ids.add(patient.db_id)
-
-        if _parsing_issue_list_contains_unconfirmed_warnings(patient.parsing_issues):
             exclude_recipients_ids.add(patient.db_id)
 
     return_donors = {
@@ -251,6 +247,6 @@ def _parsing_issue_list_contains_unconfirmed_warnings(parsing_issues: Optional[L
     if parsing_issues is None:
         return False
     for parsing_issue in parsing_issues:
-        if parsing_issue.parsing_issue_detail in WARNING_PROCESSING_RESULTS and not parsing_issue.confirmed_at:
+        if parsing_issue.parsing_issue_detail in WARNING_PROCESSING_RESULTS and parsing_issue.confirmed_at is None:
             return True
     return False

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -153,7 +153,7 @@ class TxmEvent(TxmEventBase):
         (
             self.active_and_valid_donors_dict,
             self.active_and_valid_recipients_dict,
-        ) = _filter_patients_that_dont_have_parsing_errors_or_have_confirmed_warnings(all_donors, all_recipients)
+        ) = _filter_patients_that_dont_have_parsing_errors_or_unconfirmed_warnings(all_donors, all_recipients)
 
 
 def calculate_cutoff(hla_antibodies_raw_list: List[HLAAntibodyRaw]) -> int:


### PR DESCRIPTION
Closes #860