### PR TITLE
491 make migrations and sql achemy database consistent

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = dacite,flask,flask_bcrypt,flask_restx,flask_sqlalchemy,graph_tool,gunicorn,itsdangerous,jinja2,jwt,mip,networkx,numpy,openapi_spec_validator,pandas,pdfkit,pyotp,requests,responses,sentry_sdk,sqlalchemy,swagger_unittest,werkzeug,yaml,yoyo
+known_third_party = dacite,distutils,flask,flask_bcrypt,flask_restx,flask_sqlalchemy,graph_tool,gunicorn,itsdangerous,jinja2,jwt,mip,networkx,numpy,openapi_spec_validator,pandas,pdfkit,pyotp,requests,responses,sentry_sdk,sqlalchemy,swagger_unittest,werkzeug,yaml,yoyo

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = dacite,distutils,flask,flask_bcrypt,flask_restx,flask_sqlalchemy,graph_tool,gunicorn,itsdangerous,jinja2,jwt,mip,networkx,numpy,openapi_spec_validator,pandas,pdfkit,pyotp,requests,responses,sentry_sdk,sqlalchemy,swagger_unittest,werkzeug,yaml,yoyo
+known_third_party = dacite,flask,flask_bcrypt,flask_restx,flask_sqlalchemy,graph_tool,gunicorn,itsdangerous,jinja2,jwt,mip,networkx,numpy,openapi_spec_validator,pandas,pdfkit,pyotp,requests,responses,sentry_sdk,sqlalchemy,swagger_unittest,werkzeug,yaml,yoyo

--- a/tests/database/services/test_txm_event_service.py
+++ b/tests/database/services/test_txm_event_service.py
@@ -17,6 +17,7 @@ TXM_EVENT_NAME_3 = 'txm_event_3'
 class TestTxmEventService(DbTests):
 
     def test_set_allowed_txm_event_ids_for_different_users(self):
+        txm_event_test = create_or_overwrite_txm_event('test')
         txm_event_1 = create_or_overwrite_txm_event(TXM_EVENT_NAME_1)
         txm_event_2 = create_or_overwrite_txm_event(TXM_EVENT_NAME_2)
         txm_event_3 = create_or_overwrite_txm_event(TXM_EVENT_NAME_3)
@@ -28,7 +29,7 @@ class TestTxmEventService(DbTests):
         # Admin has all txm events as allowed by default
         self.login_with_credentials(ADMIN_USER)
         event_ids = get_allowed_txm_event_ids_for_current_user()
-        self.assertCountEqual(event_ids, [txm_event_1.db_id, txm_event_2.db_id, txm_event_3.db_id])
+        self.assertCountEqual(event_ids, [txm_event_test.db_id, txm_event_1.db_id, txm_event_2.db_id, txm_event_3.db_id])
 
         # Viewer has no txm events as allowed by default
         self.login_with_credentials(VIEWER_USER)
@@ -48,7 +49,7 @@ class TestTxmEventService(DbTests):
         # Admin allowed txm events are not affected
         self.login_with_credentials(ADMIN_USER)
         event_ids = get_allowed_txm_event_ids_for_current_user()
-        self.assertCountEqual(event_ids, [txm_event_1.db_id, txm_event_2.db_id, txm_event_3.db_id])
+        self.assertCountEqual(event_ids, [txm_event_test.db_id, txm_event_1.db_id, txm_event_2.db_id, txm_event_3.db_id])
 
         # Viewer allowed txm events chaged properly
         self.login_with_credentials(VIEWER_USER)

--- a/tests/test_utilities/prepare_app_for_tests.py
+++ b/tests/test_utilities/prepare_app_for_tests.py
@@ -83,6 +83,8 @@ class DbTests(unittest.TestCase):
         add_all_namespaces(self.api)
         register_error_handlers(self.api)
 
+        # This needs to be named 'test', because of `allowed_txm_events` in `user_swagger.py`
+        create_or_overwrite_txm_event('test')
         add_users()
 
         self._set_bearer_token()

--- a/tests/web/public_api/test_public_patient_upload_data_validation.py
+++ b/tests/web/public_api/test_public_patient_upload_data_validation.py
@@ -182,7 +182,7 @@ class TestMatchingApi(DbTests):
         )
         usr = persist_user(usr)
 
-        txm_name = 'test'
+        txm_name = 'test_patient_upload_fails_on_wrong_country'
         upload_patients = {
             'country': banned_country,
             'txm_event_name': txm_name,

--- a/txmatching/database/sql_alchemy_schema.py
+++ b/txmatching/database/sql_alchemy_schema.py
@@ -14,7 +14,7 @@ from txmatching.utils.country_enum import Country
 # pylint: disable=too-few-public-methods,too-many-arguments
 # disable because sqlalchemy needs classes without public methods
 from txmatching.utils.enums import Sex, TxmEventState
-# from txmatching.utils.blood_groups import BloodGroup
+from txmatching.utils.blood_groups import BloodGroup
 from txmatching.utils.hla_system.hla_transformations.parsing_issue_detail import \
     ParsingIssueDetail
 
@@ -78,8 +78,7 @@ class RecipientModel(db.Model):
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
-    # TODO: TEXT -> Enum(BloodGroup)
-    blood = Column(TEXT, unique=False, nullable=False)
+    blood = Column(Enum(BloodGroup, values_callable=lambda x: [e.value for e in x]), unique=False, nullable=False)
     hla_typing_raw = Column(JSON, unique=False, nullable=False)
     hla_typing = Column(JSON, unique=False, nullable=False)  # HLATyping is model of the JSON
     recipient_requirements = Column(JSON, unique=False, nullable=False,
@@ -117,8 +116,7 @@ class DonorModel(db.Model):
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
-    # TODO: TEXT -> Enum(BloodGroup)
-    blood = Column(TEXT, unique=False, nullable=False)
+    blood = Column(Enum(BloodGroup, values_callable=lambda x: [e.value for e in x]), unique=False, nullable=False)
     hla_typing_raw = Column(JSON, unique=False, nullable=False)
     hla_typing = Column(JSON, unique=False, nullable=False)
     active = Column(BOOLEAN, unique=False, nullable=False)
@@ -149,8 +147,7 @@ class RecipientAcceptableBloodModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
-    # TODO: Text -> Enum(BloodGroup)
-    blood_type = Column(TEXT, unique=False, nullable=False)
+    blood_type = Column(Enum(BloodGroup, values_callable=lambda x: [e.value for e in x]), unique=False, nullable=False)
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
     deleted_at = Column(DATETIME(timezone=True), nullable=True)

--- a/txmatching/database/sql_alchemy_schema.py
+++ b/txmatching/database/sql_alchemy_schema.py
@@ -179,8 +179,7 @@ class AppUserModel(db.Model):
     email = Column(TEXT, unique=True, nullable=False)
     pass_hash = Column(TEXT, unique=False, nullable=False)
     role = Column(Enum(UserRole), unique=False, nullable=False)
-    # default_txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='SET NULL'), unique=False, nullable=True)
-    default_txm_event_id = Column(INTEGER, unique=False, nullable=True)
+    default_txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='SET NULL'), unique=False, nullable=True)
     # Whitelisted IP address if role is SERVICE
     # Seed for TOTP in all other cases
     second_factor_material = Column(TEXT, unique=False, nullable=False)

--- a/txmatching/database/sql_alchemy_schema.py
+++ b/txmatching/database/sql_alchemy_schema.py
@@ -101,8 +101,7 @@ class RecipientModel(db.Model):
     hla_antibodies_raw = relationship('HLAAntibodyRawModel', backref='recipient', passive_deletes=True,
                                       lazy='selectin')  # type: List[HLAAntibodyRawModel]
     parsing_issues = relationship('ParsingIssueModel', backref='recipient', passive_deletes=True)
-    # TODO: DEFAULT 1
-    etag = Column(BIGINT, unique=False, nullable=False)
+    etag = Column(BIGINT, unique=False, nullable=False, default=1)
     UniqueConstraint('medical_id', 'txm_event_id')
 
     def __repr__(self):
@@ -137,8 +136,7 @@ class DonorModel(db.Model):
                              passive_deletes=True,
                              lazy='joined')
     parsing_issues = relationship('ParsingIssueModel', backref='donor', passive_deletes=True)
-    # TODO: DEFAULT 1
-    etag = Column(BIGINT, unique=False, nullable=False)
+    etag = Column(BIGINT, unique=False, nullable=False, default=1)
     UniqueConstraint('medical_id', 'txm_event_id')
 
     def __repr__(self):

--- a/txmatching/database/sql_alchemy_schema.py
+++ b/txmatching/database/sql_alchemy_schema.py
@@ -1,9 +1,9 @@
 import dataclasses
 from typing import List
 
-from sqlalchemy import (BOOLEAN, JSON, TEXT, BigInteger, Column, DateTime,
-                        Enum, Float, ForeignKey, Integer, LargeBinary,
-                        UniqueConstraint)
+from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
+from sqlalchemy.types import (BOOLEAN, INTEGER, BIGINT, FLOAT,
+                              TEXT, DATETIME, JSON, BLOB, Enum)
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql import func
 
@@ -24,57 +24,57 @@ class ConfigModel(db.Model):
     __table_args__ = {'extend_existing': True}
     # Here and below I am using Integer instead of BigInt because it seems that there is a bug and BigInteger is not
     # transferred to BigSerial with autoincrement True, but to BigInt only.
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     parameters = Column(JSON, unique=False, nullable=False)
-    created_by = Column(Integer, ForeignKey('app_user.id'), unique=False, nullable=False)
+    created_by = Column(INTEGER, ForeignKey('app_user.id'), unique=False, nullable=False)
     # created at and updated at is not handled by triggers as then am not sure how tests would work, as triggers
     # seem to be specific as per db and I do not think its worth the effort as this simple approach works fine
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class PairingResultModel(db.Model):
     __tablename__ = 'pairing_result'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    original_config_id = Column(Integer, ForeignKey('config.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    original_config_id = Column(INTEGER, ForeignKey('config.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     original_config = relationship('ConfigModel', passive_deletes=True, lazy='joined')
-    patients_hash = Column(BigInteger, unique=False, nullable=False)
+    patients_hash = Column(BIGINT, unique=False, nullable=False)
     calculated_matchings = Column(JSON, unique=False, nullable=False)
     score_matrix = Column(JSON, unique=False, nullable=False)
     valid = Column(BOOLEAN, unique=False, nullable=False)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class TxmEventModel(db.Model):
     __tablename__ = 'txm_event'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     name = Column(TEXT, unique=True, nullable=False)
     configs = relationship('ConfigModel', backref='txm_event', passive_deletes=True,
                            foreign_keys='ConfigModel.txm_event_id')  # type: List[ConfigModel]
     # We do not set ForeignKey('config.id') in the following line because db.drop_all() does not
     # work otherwise (no such table: main.txm_event)
-    default_config_id = Column(BigInteger, unique=False, nullable=True)
+    default_config_id = Column(BIGINT, unique=False, nullable=True)
     state = Column(Enum(TxmEventState), unique=False, nullable=False, default=TxmEventState.OPEN)
     donors = relationship('DonorModel', backref='txm_event', passive_deletes=True)  # type: List[DonorModel]
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class RecipientModel(db.Model):
     __tablename__ = 'recipient'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
@@ -84,18 +84,17 @@ class RecipientModel(db.Model):
     hla_typing = Column(JSON, unique=False, nullable=False)  # HLATyping is model of the JSON
     recipient_requirements = Column(JSON, unique=False, nullable=False,
                                     default=dataclasses.asdict(RecipientRequirements()))
-    recipient_cutoff = Column(Integer, unique=False, nullable=False)
+    recipient_cutoff = Column(INTEGER, unique=False, nullable=False)
     sex = Column(Enum(Sex), unique=False, nullable=True)
-    height = Column(Integer, unique=False, nullable=True)
-    # TODO: Float -> Numeric
-    weight = Column(Float, unique=False, nullable=True)
-    yob = Column(Integer, unique=False, nullable=True)
+    height = Column(INTEGER, unique=False, nullable=True)
+    weight = Column(FLOAT, unique=False, nullable=True)
+    yob = Column(INTEGER, unique=False, nullable=True)
     note = Column(TEXT, unique=False, nullable=False, default='')
-    waiting_since = Column(DateTime(timezone=True), unique=False, nullable=True)
-    previous_transplants = Column(Integer, unique=False, nullable=True)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    waiting_since = Column(DATETIME(timezone=True), unique=False, nullable=True)
+    previous_transplants = Column(INTEGER, unique=False, nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
     acceptable_blood = relationship('RecipientAcceptableBloodModel', backref='recipient', passive_deletes=True,
                                     lazy='selectin')  # type: List[RecipientAcceptableBloodModel]
     hla_antibodies = Column(JSON, unique=False, nullable=False)
@@ -103,7 +102,7 @@ class RecipientModel(db.Model):
                                       lazy='selectin')  # type: List[HLAAntibodyRawModel]
     parsing_issues = relationship('ParsingIssueModel', backref='recipient', passive_deletes=True)
     # TODO: DEFAULT 1
-    etag = Column(BigInteger, unique=False, nullable=False)
+    etag = Column(BIGINT, unique=False, nullable=False)
     UniqueConstraint('medical_id', 'txm_event_id')
 
     def __repr__(self):
@@ -114,8 +113,8 @@ class DonorModel(db.Model):
     __tablename__ = 'donor'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
@@ -126,21 +125,20 @@ class DonorModel(db.Model):
     active = Column(BOOLEAN, unique=False, nullable=False)
     donor_type = Column(Enum(DonorType), unique=False, nullable=False)
     sex = Column(Enum(Sex), unique=False, nullable=True)
-    height = Column(Integer, unique=False, nullable=True)
-    # TODO: Float -> Numeric
-    weight = Column(Float, unique=False, nullable=True)
-    yob = Column(Integer, unique=False, nullable=True)
+    height = Column(INTEGER, unique=False, nullable=True)
+    weight = Column(FLOAT, unique=False, nullable=True)
+    yob = Column(INTEGER, unique=False, nullable=True)
     note = Column(TEXT, unique=False, nullable=False, default='')
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
-    recipient_id = Column(Integer, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
+    recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=True)
     recipient = relationship('RecipientModel', backref=backref('donor', uselist=False),
                              passive_deletes=True,
                              lazy='joined')
     parsing_issues = relationship('ParsingIssueModel', backref='donor', passive_deletes=True)
     # TODO: DEFAULT 1
-    etag = Column(BigInteger, unique=False, nullable=False)
+    etag = Column(BIGINT, unique=False, nullable=False)
     UniqueConstraint('medical_id', 'txm_event_id')
 
     def __repr__(self):
@@ -151,27 +149,27 @@ class RecipientAcceptableBloodModel(db.Model):
     __tablename__ = 'recipient_acceptable_blood'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    recipient_id = Column(Integer, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     # TODO: Text -> Enum(BloodGroup)
     blood_type = Column(TEXT, unique=False, nullable=False)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class HLAAntibodyRawModel(db.Model):
     __tablename__ = 'hla_antibody_raw'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    recipient_id = Column(Integer, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     raw_code = Column(TEXT, unique=False, nullable=False)
-    mfi = Column(Integer, unique=False, nullable=False)
-    cutoff = Column(Integer, unique=False, nullable=False)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    mfi = Column(INTEGER, unique=False, nullable=False)
+    cutoff = Column(INTEGER, unique=False, nullable=False)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
     def __repr__(self):
         return f'<HLAAntibodyRawModel {self.id} ' \
@@ -182,11 +180,12 @@ class AppUserModel(db.Model):
     __tablename__ = 'app_user'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     email = Column(TEXT, unique=True, nullable=False)
     pass_hash = Column(TEXT, unique=False, nullable=False)
     role = Column(Enum(UserRole), unique=False, nullable=False)
-    default_txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='SET NULL'), unique=False, nullable=True)
+    # default_txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='SET NULL'), unique=False, nullable=True)
+    default_txm_event_id = Column(INTEGER, unique=False, nullable=True)
     # Whitelisted IP address if role is SERVICE
     # Seed for TOTP in all other cases
     second_factor_material = Column(TEXT, unique=False, nullable=False)
@@ -195,9 +194,9 @@ class AppUserModel(db.Model):
     allowed_edit_countries = Column(JSON, unique=False, nullable=False, default=lambda: [])
     reset_token = Column(TEXT, unique=False, nullable=True, default=None)
 
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class UserToAllowedEvent(db.Model):
@@ -205,12 +204,12 @@ class UserToAllowedEvent(db.Model):
     __table_args__ = {'extend_existing': True}
 
     user_id = Column(
-        Integer,
+        INTEGER,
         ForeignKey('app_user.id', onupdate='CASCADE', ondelete='CASCADE'),
         unique=False, nullable=False, primary_key=True, index=True
     )
     txm_event_id = Column(
-        Integer,
+        INTEGER,
         ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'),
         unique=False, nullable=False, primary_key=True, index=True
     )
@@ -220,55 +219,55 @@ class UploadedDataModel(db.Model):
     __tablename__ = 'uploaded_data'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
-    user_id = Column(Integer, ForeignKey('app_user.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    user_id = Column(INTEGER, ForeignKey('app_user.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
     uploaded_data = Column(JSON, unique=False, nullable=False)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now(),
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
+    updated_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now(),
                         onupdate=func.now())
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
 
 
 class ParsingIssueModel(db.Model):
     __tablename__ = 'parsing_issue'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     hla_code_or_group = Column(TEXT, unique=False, nullable=True)
     parsing_issue_detail = Column(Enum(ParsingIssueDetail), unique=False, nullable=False)
     message = Column(TEXT, unique=False, default='')
-    donor_id = Column(Integer, ForeignKey('donor.id', ondelete='CASCADE'), unique=False, nullable=True)
-    recipient_id = Column(Integer, ForeignKey('recipient.id', ondelete='CASCADE'), unique=False, nullable=True)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', ondelete='CASCADE'), unique=False, nullable=True)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
+    donor_id = Column(INTEGER, ForeignKey('donor.id', ondelete='CASCADE'), unique=False, nullable=True)
+    recipient_id = Column(INTEGER, ForeignKey('recipient.id', ondelete='CASCADE'), unique=False, nullable=True)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', ondelete='CASCADE'), unique=False, nullable=True)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(
-        DateTime(timezone=True),
+        DATETIME(timezone=True),
         unique=False,
         nullable=False,
         server_default=func.now(),
         onupdate=func.now()
     )
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
-    confirmed_at = Column(DateTime(timezone=True), unique=False, nullable=True)
-    confirmed_by = Column(Integer, ForeignKey('app_user.id', ondelete='SET NULL'), unique=False, nullable=True)
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)
+    confirmed_at = Column(DATETIME(timezone=True), unique=False, nullable=True)
+    confirmed_by = Column(INTEGER, ForeignKey('app_user.id', ondelete='SET NULL'), unique=False, nullable=True)
 
 
 class UploadedFileModel(db.Model):
     __tablename__ = 'uploaded_file'
     __table_args__ = {'extend_existing': True}
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     file_name = Column(TEXT, unique=False, nullable=False)
-    file = Column(LargeBinary, unique=False, nullable=False)
-    txm_event_id = Column(Integer, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
-    user_id = Column(Integer, ForeignKey('app_user.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
-    created_at = Column(DateTime(timezone=True), unique=False, nullable=False, server_default=func.now())
+    file = Column(BLOB, unique=False, nullable=False)
+    txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    user_id = Column(INTEGER, ForeignKey('app_user.id', onupdate='CASCADE', ondelete='CASCADE'), unique=False, nullable=False)
+    created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(
-        DateTime(timezone=True),
+        DATETIME(timezone=True),
         unique=False,
         nullable=False,
         server_default=func.now(),
         onupdate=func.now()
     )
-    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    deleted_at = Column(DATETIME(timezone=True), nullable=True)

--- a/txmatching/templates/report_includes/transplant_component.macro.html
+++ b/txmatching/templates/report_includes/transplant_component.macro.html
@@ -129,18 +129,18 @@
         <td>Blood type</td>
         <td>
           <div class="code {% if compatible_blood %}matching{% endif %}">
-            {{ donor.parameters.blood_group }}
+            {{ donor.parameters.blood_group.value }}
           </div>
         </td>
         <td colspan="2">
           {% if recipient %}
             <div class="code {% if compatible_blood %}matching{% endif %}">
-              {{ recipient.parameters.blood_group }}
+              {{ recipient.parameters.blood_group.value }}
             </div>
             <div class="small">
               Acceptable:
               {% for code in recipient.acceptable_blood_groups %}
-                <div class="code">{{ code }}</div>
+                <div class="code">{{ code.value }}</div>
               {% endfor %}
             </div>
           {% endif %}


### PR DESCRIPTION
Fixes #491 consistency, not approach to ensure consistency each migration.

@kubantjan Should `default_txm_event_id` be a foreign key? In case of yes, I'd need to create `txm_event(id=1)` in `prepare_app_for_tests.DbTests.setUp` before `add_users()`.