### PR TITLE
Simplify `get_crossmatchted_antibodies`

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -143,7 +143,7 @@ Example for case 3: donor has antigen DR8, and the recipient has antibodies DRB1
 
 #### SPLIT
 1. Donor antigen is in split resolution and the recipient has a matching antibody in split or high resolution (after conversion)
-2. Donor antigen is in high resolution and the recipient has a matching antibody in split resolution
+2. Donor antigen is in high resolution and the recipient is type B and the recipient has a matching antibody in split resolution
 
 Example for case 1: donor has antigen DQ8 and the recipient has antibody DRB1\*08:01 or donor has antigen DQ8 and the recipient has antibody DQ8
 
@@ -166,7 +166,7 @@ Example for case 3:
   - DRB1\*08:03 with MFI 1800
 #### BROAD
 1. Donor antigen is in broad resolution and the recipient has a matching antibody in split/broad/high resolution
-2. Donor antigen is in high/split/broad resolution and the recipient has a matching antibody in broad resolution
+2. Donor antigen is in high/split/broad resolution and the recipient is type B and the recipient has a matching antibody in broad resolution
 
 Example for both cases: donor has antigen DQ3 and the recipient has antibody DQ3.
 

--- a/tests/utils/hla_system/test_crossmatch.py
+++ b/tests/utils/hla_system/test_crossmatch.py
@@ -80,7 +80,7 @@ class TestCrossmatch(unittest.TestCase):
 
         # there is no antibody below the cutoff
         antibodies[0] = create_antibody(antibodies[0].raw_code, 2100, 2000)
-        self.assertFalse(is_recipient_type_a(create_antibodies(antibodies[:-1])))
+        self.assertFalse(is_recipient_type_a(create_antibodies(antibodies)))
 
     def test_crossmatch_split(self):
         """
@@ -242,8 +242,9 @@ class TestCrossmatch(unittest.TestCase):
 
     def test_get_crossmatched_antibodies(self):
         """
-        Also checks the matches that the get_crossmatched_antibodies function returns.
+        Checks the matches that the `get_crossmatched_antibodies` function returns.
         """
+
         self._assert_raw_code_equal('A*23:01', HLACode('A*23:01', 'A23', 'A9'))
         self._assert_raw_code_equal('A*23:04', HLACode('A*23:04', 'A23', 'A9'))
         self._assert_raw_code_equal('A*24:02', HLACode('A*24:02', 'A24', 'A9'))

--- a/tests/utils/hla_system/test_crossmatch.py
+++ b/tests/utils/hla_system/test_crossmatch.py
@@ -327,18 +327,6 @@ class TestCrossmatch(unittest.TestCase):
                                                   AntibodyMatchTypes.HIGH_RES_WITH_SPLIT)],
                                    is_type_a=True)
 
-        # TODO: Je toto potřeba? `create_antibodies` stejně volá nějaké parsování,
-        #  takže `hla_antibody_list` bude naplněn stejně
-        #  při (mfi < cutoff, mfi > cutoff) jako při (mfi > cutoff, mfi < cutoff)
-        # TODO: Pokud není, !zjednodušit! komentáře u jednotlivých testů
-        # # first matching antibody with mfi < cutoff, second with mfi > cutoff  # HIGH_RES_WITH_SPLIT_1
-        # self._assert_matches_equal('A23',
-        #                            [create_antibody('A*23:01', 1900, 2000),
-        #                             create_antibody('A*23:04', 2100, 2000)], True,
-        #                            [AntibodyMatch(create_antibody('A*23:04', 2100, 2000),
-        #                                           AntibodyMatchTypes.HIGH_RES_WITH_SPLIT)],
-        #                            is_type_a=True)
-
         # first matching antibody with mfi > cutoff, second with mfi < cutoff  # HIGH_RES_WITH_SPLIT_2
         self._assert_matches_equal('A*24:02',
                                    [create_antibody('A*24:37', 2100, 2000),
@@ -355,15 +343,6 @@ class TestCrossmatch(unittest.TestCase):
                                     create_antibody('A9', 2100, 2000)], True,
                                    [AntibodyMatch(create_antibody('A9', 2000, 2000), AntibodyMatchTypes.BROAD)],
                                    is_type_a=False)
-
-        # TODO: Tohle už je taky podle mě zbytečné, protože to, že se správně počítá průměr mfi jsme zjistili už nahoře
-        #  a to, že funguje BROAD_1 jsme zjistili test nad tímto
-        # # first matching antibody with mfi1 > cutoff, second with mfi2 > mfi1  # BROAD_1
-        # self._assert_matches_equal('A9',
-        #                            [create_antibody('A9', 2100, 2000),
-        #                             create_antibody('A9', 2200, 2000)], True,
-        #                            [AntibodyMatch(create_antibody('A9', 2150, 2000), AntibodyMatchTypes.BROAD)],
-        #                            is_type_a=False)
 
         # first matching antibody with mfi < cutoff, second with mfi > cutoff  # BROAD_2
         self._assert_matches_equal('A*23:01',

--- a/tests/utils/hla_system/test_crossmatch.py
+++ b/tests/utils/hla_system/test_crossmatch.py
@@ -268,7 +268,7 @@ class TestCrossmatch(unittest.TestCase):
                                    [create_antibody('A*23:01', 1900, 2000),
                                     create_antibody('A23', 2100, 2000)], True,
                                    [AntibodyMatch(create_antibody('A23', 2100, 2000), AntibodyMatchTypes.NONE)],
-                                   is_type_a=False)
+                                   is_type_a=True)
 
     def test_antibodies_with_multiple_mfis(self):
         self._assert_raw_code_equal('A*23:01', HLACode('A*23:01', 'A23', 'A9'))

--- a/tests/utils/hla_system/test_crossmatch.py
+++ b/tests/utils/hla_system/test_crossmatch.py
@@ -1,7 +1,9 @@
 import logging
+import os
 import unittest
-from typing import List
+from typing import Callable, List
 
+from local_testing_utilities.generate_patients import LARGE_DATA_FOLDER
 from tests.test_utilities.hla_preparation_utils import (create_antibodies,
                                                         create_antibody,
                                                         create_hla_type,
@@ -9,38 +11,45 @@ from tests.test_utilities.hla_preparation_utils import (create_antibodies,
 from txmatching.patients.hla_code import HLACode
 from txmatching.patients.hla_model import HLAAntibody
 from txmatching.utils.enums import AntibodyMatchTypes, HLACrossmatchLevel
-from txmatching.utils.hla_system.hla_crossmatch import (
-    AntibodyMatch, is_positive_hla_crossmatch,
-    _do_crossmatch_in_type_a,
-    _do_crossmatch_in_type_b, MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A, _is_recipient_type_a)
+from txmatching.utils.hla_system.hla_crossmatch import (AntibodyMatch, do_crossmatch_in_type_a, do_crossmatch_in_type_b,
+                                                        is_positive_hla_crossmatch, is_recipient_type_a)
 
 logger = logging.getLogger(__name__)
 
 
 class TestCrossmatch(unittest.TestCase):
 
-    def _assert_positive_crossmatch(self, hla_type: str, hla_antibodies: List[HLAAntibody], use_high_resolution: bool,
+    def _assert_positive_crossmatch(self,
+                                    hla_type: str,
+                                    hla_antibodies: List[HLAAntibody],
+                                    use_high_resolution: bool,
+                                    crossmatch_logic: Callable,
                                     crossmatch_level: HLACrossmatchLevel = HLACrossmatchLevel.NONE):
         self.assertTrue(
             is_positive_hla_crossmatch(
                 create_hla_typing(hla_types_list=[hla_type]),
                 create_antibodies(hla_antibodies_list=hla_antibodies),
                 use_high_resolution,
-                crossmatch_level
-            ), f'{hla_type} and {hla_antibodies} has NEGATIVE crossmatch (use_high_resolution={use_high_resolution})'
+                crossmatch_level,
+                crossmatch_logic
+            ), f'{hla_type} and {hla_antibodies} has NEGATIVE crossmatch ({use_high_resolution = })'
         )
 
-    def _assert_negative_crossmatch(self, hla_type_raw: str, hla_antibodies: List[HLAAntibody],
+    def _assert_negative_crossmatch(self,
+                                    hla_type: str,
+                                    hla_antibodies: List[HLAAntibody],
                                     use_high_resolution: bool,
+                                    crossmatch_logic: Callable,
                                     crossmatch_level: HLACrossmatchLevel = HLACrossmatchLevel.NONE):
         self.assertFalse(
             is_positive_hla_crossmatch(
-                create_hla_typing(hla_types_list=[hla_type_raw]),
+                create_hla_typing(hla_types_list=[hla_type]),
                 create_antibodies(hla_antibodies_list=hla_antibodies),
                 use_high_resolution,
-                crossmatch_level
+                crossmatch_level,
+                crossmatch_logic
             ),
-            f'{hla_type_raw} and {hla_antibodies} has POSITIVE crossmatch (use_high_resolution={use_high_resolution})'
+            f'{hla_type} and {hla_antibodies} has POSITIVE crossmatch ({use_high_resolution = })'
         )
 
     def _assert_raw_code_equal(self, raw_code: str, expected_hla_code: HLACode):
@@ -48,32 +57,30 @@ class TestCrossmatch(unittest.TestCase):
         self.assertEqual(expected_hla_code, actual_hla_code)
 
     def test_is_recipient_type_a(self):
-        # MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A = 20
-        # load 10 + 10 unique high resolution antibodies from the resource file
-        with open("../../resources/high_res_example_data/high_res_example_data_CZE.json") as f:
+        with open(os.path.join(LARGE_DATA_FOLDER, "high_res_example_data_CZE.json")) as f:
             import json
             data = json.load(f)
 
-            hla_typing = data["donors"][0]["hla_typing"]
-            hla_typing.extend(data["donors"][1]["hla_typing"])
+            hla_typing = data["donors"][0]["hla_typing"]  # len = 10
+            hla_typing.extend(data["donors"][1]["hla_typing"])  # len = 10
 
             antibodies = [create_antibody(hla, 2100, 2000) for hla in hla_typing]
-            # set first antibody to negative to fulfill the criteria
+            # set first antibody to be negative to fulfill the criteria
             antibodies[0] = create_antibody(antibodies[0].raw_code, 1900, 2000)
 
         # all criteria are fulfilled
-        self.assertTrue(_is_recipient_type_a(create_antibodies(antibodies)))
+        self.assertTrue(is_recipient_type_a(create_antibodies(antibodies)))
 
         # not all antibodies are in high resolution
         antibodies[0] = create_antibody("A9", 2100, 2000)
-        self.assertFalse(_is_recipient_type_a(create_antibodies(antibodies)))
+        self.assertFalse(is_recipient_type_a(create_antibodies(antibodies)))
 
         # there is less than `MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A`
-        self.assertFalse(_is_recipient_type_a(create_antibodies(antibodies[:-1])))
+        self.assertFalse(is_recipient_type_a(create_antibodies(antibodies[:-1])))
 
         # there is no antibody below the cutoff
         antibodies[0] = create_antibody(antibodies[0].raw_code, 2100, 2000)
-        self.assertFalse(_is_recipient_type_a(create_antibodies(antibodies[:-1])))
+        self.assertFalse(is_recipient_type_a(create_antibodies(antibodies[:-1])))
 
     def test_crossmatch_split(self):
         """
@@ -87,40 +94,52 @@ class TestCrossmatch(unittest.TestCase):
         self._assert_raw_code_equal('A*23:04', HLACode('A*23:04', 'A23', 'A9'))
         self._assert_raw_code_equal('A*24:02', HLACode('A*24:02', 'A24', 'A9'))
 
-        self._assert_positive_crossmatch('A9', [create_antibody('A9', 2100, 2000)], False)
-        self._assert_negative_crossmatch('A9', [create_antibody('A9', 1900, 2000)], False)
+        self._assert_positive_crossmatch('A9', [create_antibody('A9', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
+        self._assert_negative_crossmatch('A9', [create_antibody('A9', 1900, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
-        self._assert_negative_crossmatch('A23', [create_antibody('A24', 2100, 2000)], False)
+        self._assert_negative_crossmatch('A23', [create_antibody('A24', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
         # broad crossmatch
-        self._assert_positive_crossmatch('A9', [create_antibody('A23', 2100, 2000)], False)
-        self._assert_negative_crossmatch('A9', [create_antibody('A1', 2100, 2000)], False)
+        self._assert_positive_crossmatch('A9', [create_antibody('A23', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
+        self._assert_negative_crossmatch('A9', [create_antibody('A1', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
         # with high res code specified:
 
         # positive split crossmatch
-        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:04', 2100, 2000)], False)
+        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:04', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_a)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*24:02', 2100, 2000)], False)
+        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*24:02', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # positive split crossmatch
-        self._assert_positive_crossmatch('A*23:04', [create_antibody('A23', 2100, 2000)], False)
+        self._assert_positive_crossmatch('A*23:04', [create_antibody('A23', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A*23:04', [create_antibody('A24', 2100, 2000)], False)
+        self._assert_negative_crossmatch('A*23:04', [create_antibody('A24', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
         # split crossmatch with multiple antibodies:
 
         # positive split crossmatch
         self._assert_positive_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 1900, 2000),
-                                          create_antibody('A*23:04', 2100, 2000)], False)
+                                          create_antibody('A*23:04', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_a)
         # positive high res crossmatch
         self._assert_positive_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 1900, 2000),
-                                          create_antibody('A23', 2100, 2000)], False)
+                                          create_antibody('A23', 2100, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative high res crossmatch
         self._assert_negative_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 1900, 2000),
-                                          create_antibody('A23', 1900, 2000)], False)
+                                          create_antibody('A23', 1900, 2000)], False,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
     def test_crossmatch_high_res(self):
         """
@@ -133,56 +152,74 @@ class TestCrossmatch(unittest.TestCase):
         # mfi > cutoff:
 
         # positive high res crossmatch
-        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:01', 2100, 2000)], True)
+        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:01', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # positive split crossmatch
-        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:04', 2100, 2000)], True)
+        self._assert_positive_crossmatch('A*23:01', [create_antibody('A*23:04', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_a)
         # positive split crossmatch
-        self._assert_positive_crossmatch('A23', [create_antibody('A*23:04', 2100, 2000)], True)
+        self._assert_positive_crossmatch('A23', [create_antibody('A*23:04', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # positive split crossmatch
-        self._assert_positive_crossmatch('A*23:04', [create_antibody('A23', 2100, 2000)], True)
+        self._assert_positive_crossmatch('A*23:04', [create_antibody('A23', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # positive split crossmatch
-        self._assert_positive_crossmatch('A23', [create_antibody('A23', 2100, 2000)], True)
+        self._assert_positive_crossmatch('A23', [create_antibody('A23', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A24', [create_antibody('A*23:04', 2100, 2000)], True)
+        self._assert_negative_crossmatch('A24', [create_antibody('A*23:04', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A*23:04', [create_antibody('A24', 2100, 2000)], True)
+        self._assert_negative_crossmatch('A*23:04', [create_antibody('A24', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A23', [create_antibody('A24', 2100, 2000)], True)
+        self._assert_negative_crossmatch('A23', [create_antibody('A24', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*24:02', 2100, 2000)], True)
+        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*24:02', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
         # mfi < cutoff:
 
         # negative high res crossmatch
-        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*23:01', 1900, 2000)], True)
+        self._assert_negative_crossmatch('A*23:01', [create_antibody('A*23:01', 1900, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A23', [create_antibody('A*23:04', 1900, 2000)], True)
+        self._assert_negative_crossmatch('A23', [create_antibody('A*23:04', 1900, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A*23:04', [create_antibody('A23', 1900, 2000)], True)
+        self._assert_negative_crossmatch('A*23:04', [create_antibody('A23', 1900, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative split crossmatch
-        self._assert_negative_crossmatch('A23', [create_antibody('A23', 1900, 2000)], True)
+        self._assert_negative_crossmatch('A23', [create_antibody('A23', 1900, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
         # multiple antibodies
 
         # positive high res crossmatch
         self._assert_positive_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 2100, 2000),
-                                          create_antibody('A*23:04', 2100, 2000)], True)
+                                          create_antibody('A*23:04', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative high res crossmatch
         self._assert_negative_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 1900, 2000),
-                                          create_antibody('A*23:04', 2100, 2000)], True)
+                                          create_antibody('A*23:04', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # positive high res crossmatch
         self._assert_positive_crossmatch('A*23:01',
-                                         [create_antibody('A23', 2100, 2000)], True)
+                                         [create_antibody('A23', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
         # negative high res crossmatch
         self._assert_negative_crossmatch('A*23:01',
                                          [create_antibody('A*23:01', 1900, 2000),
-                                          create_antibody('A23', 2100, 2000)], True)
+                                          create_antibody('A23', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_a)
         # positive split crossmatch
         self._assert_positive_crossmatch('A*23:01',
                                          [create_antibody('A*23:04', 1900, 2000),
-                                          create_antibody('A23', 2100, 2000)], True)
+                                          create_antibody('A23', 2100, 2000)], True,
+                                         crossmatch_logic=do_crossmatch_in_type_b)
 
     def _assert_matches_equal(self,
                               hla_type: str, hla_antibodies: List[HLAAntibody],
@@ -191,7 +228,7 @@ class TestCrossmatch(unittest.TestCase):
                               is_type_a: bool):
 
         # False -> 0 | True -> 1
-        crossmatch_type_functions = [_do_crossmatch_in_type_b, _do_crossmatch_in_type_a]
+        crossmatch_type_functions = [do_crossmatch_in_type_b, do_crossmatch_in_type_a]
         crossmatched_antibodies = crossmatch_type_functions[is_type_a](
             create_hla_typing(hla_types_list=[hla_type]),
             create_antibodies(hla_antibodies_list=hla_antibodies),
@@ -452,20 +489,30 @@ class TestCrossmatch(unittest.TestCase):
                                                 create_antibody('A*23:01', 2100, 2000),
                                                 create_antibody('A*23:04', 2100, 2000)]
 
-        self._assert_negative_crossmatch('A9', high_res_antibodies_not_all_positive, True, HLACrossmatchLevel.BROAD)
+        self._assert_negative_crossmatch('A9', high_res_antibodies_not_all_positive, True,
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.BROAD)
 
-        self._assert_positive_crossmatch('A9', high_res_antibodies_all_positive, True, HLACrossmatchLevel.BROAD)
+        self._assert_positive_crossmatch('A9', high_res_antibodies_all_positive, True,
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.BROAD)
 
-        self._assert_positive_crossmatch('A9', high_res_antibodies_not_all_positive, True, HLACrossmatchLevel.NONE)
+        self._assert_positive_crossmatch('A9', high_res_antibodies_not_all_positive, True,
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.NONE)
 
-        self._assert_positive_crossmatch('A9', high_res_antibodies_all_positive, True, HLACrossmatchLevel.NONE)
+        self._assert_positive_crossmatch('A9', high_res_antibodies_all_positive, True,
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.NONE)
 
         self._assert_negative_crossmatch('A23',
                                          [create_antibody('A*23:01', 1900, 2000),
                                           create_antibody('A*23:04', 2100, 2000)], True,
-                                         HLACrossmatchLevel.SPLIT_AND_BROAD)
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.SPLIT_AND_BROAD)
 
         self._assert_positive_crossmatch('A23',
                                          [create_antibody('A*23:01', 2100, 2000),
                                           create_antibody('A*23:04', 2100, 2000)], True,
-                                         HLACrossmatchLevel.SPLIT_AND_BROAD)
+                                         crossmatch_logic=do_crossmatch_in_type_a,
+                                         crossmatch_level=HLACrossmatchLevel.SPLIT_AND_BROAD)

--- a/tests/web/test_patient_api.py
+++ b/tests/web/test_patient_api.py
@@ -567,11 +567,9 @@ class TestPatientService(DbTests):
                              headers=self.auth_headers)
         self.assertEqual(200, res.status_code)
 
-        # Because there is a uniqueness between antibodies in high resolution and
-        # the server deals with it, means: it will store ['A*01:01', 'A*01:01', 'B*01:01'] like ['A*01:01', 'B*01:01'].
-        # When we compare the raw codes, we need to care of uniqueness as well.
-        # So list(dict(zip(antibodies, antibodies))) removes duplicates and doesn't sort a list.
-        expected_antibody_raw_codes = [antibody[0] for antibody in list(dict(zip(antibodies, antibodies)))]
+        # Using code from the link to get unique antibody raw codes while preserving order:
+        # https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order
+        expected_antibody_raw_codes = [antibody[0] for antibody in list(dict.fromkeys(antibodies))]
         for donor in res.json['donors']:
             antibodies_raw_codes = []
             for detailed_score_for_group in donor['detailed_score_with_related_recipient']:

--- a/txmatching/utils/hla_system/README.md
+++ b/txmatching/utils/hla_system/README.md
@@ -1,0 +1,9 @@
+In `do_crossmatch_in_type_a` and `do_crossmatch_in_type_b` we tend to refer to individual steps from [Mild Blue documentation](https://github.com/mild-blue/txmatching/tree/master/documentation).
+
+We use the notation `TYPIZATION_X` where `X` is the given step, e.g. `HIGH_RES_1`, `SPLIT_2`, etc.
+
+- [HIGH RES steps](https://github.com/mild-blue/txmatching/tree/master/documentation#high-res)
+- [HIGH RES WITH SPLIT steps](https://github.com/mild-blue/txmatching/tree/master/documentation#high_res_with_split)
+- [BROAD steps](https://github.com/mild-blue/txmatching/tree/master/documentation#broad)
+- [HIGH RES WITH BROAD steps](https://github.com/mild-blue/txmatching/tree/master/documentation#high_res_with_broad)
+- [UNDECIDABLE](https://github.com/mild-blue/txmatching/tree/master/documentation#undecidable)

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -53,10 +53,6 @@ def _get_antibodies_over_cutoff(antibodies: List[HLAAntibody]) -> List[HLAAntibo
     return [antibody for antibody in antibodies if antibody.mfi >= antibody.cutoff]
 
 
-def _get_antibodies_with_high_res(antibodies: List[HLAAntibody]) -> List[HLAAntibody]:
-    return [antibody for antibody in antibodies if antibody.code.high_res]
-
-
 def _add_undecidable_typization(antibodies: List[HLAAntibody], hla_per_group: HLAPerGroup,
                                 positive_matches: List[AntibodyMatch]):
     if hla_per_group.hla_group == HLAGroup.Other:
@@ -232,7 +228,7 @@ def _is_recipient_type_a(recipient_antibodies: HLAAntibodies) -> bool:
     if total_antibodies < MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A:
         return False
 
-    if is_at_least_one_antibody_below_cutoff:
+    if not is_at_least_one_antibody_below_cutoff:
         return False
 
     return True

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -193,8 +193,13 @@ def _do_crossmatch_in_type_b(donor_hla_typing: HLATyping,
                     continue
 
             if hla_type.code.split is not None:
-                tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                if hla_type.code.split == antibody.code.split]
+                if hla_type.code.high_res is None:  # SPLIT_1
+                    tested_antibodies_that_match = [antibody for antibody in antibodies
+                                                    if hla_type.code.split == antibody.code.split]
+                else:  # SPLIT_2
+                    tested_antibodies_that_match = [antibody for antibody in antibodies
+                                                    if hla_type.code.split == antibody.code.split
+                                                    and antibody.code.high_res is None]
                 if len(tested_antibodies_that_match) > 0:
                     for match in tested_antibodies_that_match:
                         # SPLIT_1, SPLIT_2

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -6,7 +6,6 @@ from txmatching.patients.hla_model import HLAAntibodies, HLAAntibody, HLAType, H
 from txmatching.utils.enums import (AntibodyMatchTypes, HLACrossmatchLevel,
                                     HLAGroup)
 
-
 MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A = 20
 
 
@@ -26,7 +25,80 @@ def _get_antibodies_over_cutoff(antibodies: List[HLAAntibody]) -> List[HLAAntibo
     return [antibody for antibody in antibodies if antibody.mfi >= antibody.cutoff]
 
 
-def _add_undecidable_typization(antibodies: List[HLAAntibody], hla_per_group: HLAPerGroup,
+def _add_all_tested_antibodies_are_positive(tested_antibodies_that_match: List[HLAAntibody],
+                                            positive_tested_antibodies: List[HLAAntibody],
+                                            match_type: AntibodyMatchTypes,
+                                            positive_matches: List[AntibodyMatch]) -> bool:
+    """Return True if crossmatching has happened."""
+
+    if len(positive_tested_antibodies) > 0:
+        if len(tested_antibodies_that_match) == len(positive_tested_antibodies):
+            for antibody in tested_antibodies_that_match:
+                positive_matches.append(AntibodyMatch(antibody, match_type))
+            return True
+    return False
+
+
+def _add_positive_tested_antibodies(tested_antibodies_that_match: List[HLAAntibody],
+                                    match_type: AntibodyMatchTypes,
+                                    positive_matches: List[AntibodyMatch]) -> bool:
+    """Return True if crossmatching has happened."""
+
+    if len(tested_antibodies_that_match) > 0:
+        for antibody in _get_antibodies_over_cutoff(tested_antibodies_that_match):
+            positive_matches.append(AntibodyMatch(antibody, match_type))
+        return True
+    return False
+
+
+def _add_split_typization(hla_type: HLAType,
+                          tested_antibodies_that_match: List[HLAAntibody],
+                          positive_matches: List[AntibodyMatch]) -> bool:
+    """Return True if split crossmatching has happened."""
+
+    # SPLIT_1
+    if hla_type.code.high_res is None:
+        if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                           AntibodyMatchTypes.SPLIT,
+                                           positive_matches):
+            return True
+
+    tested_antibodies_that_match = [antibody for antibody in tested_antibodies_that_match
+                                    if antibody.code.high_res is None]
+    # SPLIT_2
+    if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                       AntibodyMatchTypes.SPLIT,
+                                       positive_matches):
+        return True
+
+    return False
+
+
+def _add_broad_typization(hla_type: HLAType,
+                          tested_antibodies_that_match: List[HLAAntibody],
+                          positive_matches: List[AntibodyMatch]) -> bool:
+    """Return True if broad crossmatching has happened."""
+
+    # BROAD_1
+    if hla_type.code.high_res is None and hla_type.code.split is None:
+        if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                           AntibodyMatchTypes.BROAD,
+                                           positive_matches):
+            return True
+
+    tested_antibodies_that_match = [antibody for antibody in tested_antibodies_that_match
+                                    if antibody.code.high_res is None and antibody.code.split is None]
+    # BROAD_2
+    if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                       AntibodyMatchTypes.BROAD,
+                                       positive_matches):
+        return True
+
+    return False
+
+
+def _add_undecidable_typization(antibodies: List[HLAAntibody],
+                                hla_per_group: HLAPerGroup,
                                 positive_matches: List[AntibodyMatch]):
     if hla_per_group.hla_group == HLAGroup.Other:
         groups_other = {hla_type.code.group for hla_type in hla_per_group.hla_types}
@@ -43,33 +115,13 @@ def _add_none_typization(antibodies: List[HLAAntibody],
             positive_matches.append(AntibodyMatch(antibody, AntibodyMatchTypes.NONE))
 
 
-# def _do_crossmatch(tested_antibodies_that_match: List[HLAAntibody], positive_matches: List[AntibodyMatch],
-#                    type__all_tested_antibodies_are_positive: AntibodyMatchTypes,
-#                    type__only_positive_tested_antibodies: AntibodyMatchTypes) -> bool:
-#     """Return `True` if some crossmatching happened."""
-#
-#     positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
-#
-#     if len(positive_tested_antibodies) > 0:
-#         if len(tested_antibodies_that_match) == len(positive_tested_antibodies):
-#             for match in tested_antibodies_that_match:
-#                 positive_matches.append(AntibodyMatch(match, type__all_tested_antibodies_are_positive))
-#             return True
-#
-#         for match in positive_tested_antibodies:
-#             positive_matches.append(AntibodyMatch(match, type__only_positive_tested_antibodies))
-#         return True
-#
-#     return len(tested_antibodies_that_match) != 0 or False
-
-
 def _recipient_was_tested_for_donor_antigen(antibodies: List[HLAAntibody], antigen: HLACode) -> bool:
     return antigen in [antibody.code for antibody in antibodies]
 
 
 def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
-                             recipient_antibodies: HLAAntibodies,
-                             use_high_resolution: bool) -> List[AntibodyMatchForHLAGroup]:
+                            recipient_antibodies: HLAAntibodies,
+                            use_high_resolution: bool) -> List[AntibodyMatchForHLAGroup]:
     antibody_matches_for_groups = []
 
     for hla_per_group, antibodies_per_group in zip(donor_hla_typing.hla_per_groups,
@@ -84,31 +136,30 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                 tested_antibodies_that_match = [antibody for antibody in antibodies
                                                 if hla_type.code.high_res == antibody.code.high_res]
 
-                if len(tested_antibodies_that_match) > 0:
-                    for match in _get_antibodies_over_cutoff(tested_antibodies_that_match):
-                        # HIGH_RES_1
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES))
+                # HIGH_RES_1
+                if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                                   AntibodyMatchTypes.HIGH_RES,
+                                                   positive_matches):
                     continue
 
-                if _recipient_was_tested_for_donor_antigen(antibodies, hla_type.code):
-                    continue
+                if not _recipient_was_tested_for_donor_antigen(antibodies, hla_type.code):
+                    tested_antibodies_that_match = [antibody for antibody in antibodies
+                                                    if hla_type.code.split == antibody.code.split
+                                                    if hla_type.code.split is not None]
+                    positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
 
-                tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                if hla_type.code.split == antibody.code.split
-                                                if hla_type.code.split is not None]
-                positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
-
-                if len(positive_tested_antibodies) > 0:
-                    if len(tested_antibodies_that_match) == len(positive_tested_antibodies):
-                        for match in tested_antibodies_that_match:
-                            # HIGH_RES_2
-                            positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES))
+                    # HIGH_RES_2
+                    if _add_all_tested_antibodies_are_positive(tested_antibodies_that_match,
+                                                               positive_tested_antibodies,
+                                                               AntibodyMatchTypes.HIGH_RES,
+                                                               positive_matches):
                         continue
 
-                    for match in positive_tested_antibodies:
-                        # HIGH_RES_WITH_SPLIT_2
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES_WITH_SPLIT))
-                    continue
+                    # HIGH_RES_WITH_SPLIT_2
+                    if _add_positive_tested_antibodies(positive_tested_antibodies,
+                                                       AntibodyMatchTypes.HIGH_RES_WITH_SPLIT,
+                                                       positive_matches):
+                        continue
 
             if hla_type.code.split is not None:
                 tested_antibodies_that_match = [antibody for antibody in antibodies
@@ -116,32 +167,21 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                                                 if hla_type.code.split is not None]
                 positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
 
-                if len(positive_tested_antibodies) > 0:
-                    if (hla_type.code.high_res is None
-                            and (len(tested_antibodies_that_match) == len(positive_tested_antibodies))):
-                        for match in tested_antibodies_that_match:
-                            # HIGH_RES_3
-                            positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES))
+                # HIGH_RES_3
+                if hla_type.code.high_res is None:
+                    if _add_all_tested_antibodies_are_positive(tested_antibodies_that_match,
+                                                               positive_tested_antibodies,
+                                                               AntibodyMatchTypes.HIGH_RES,
+                                                               positive_matches):
                         continue
 
-                    for match in positive_tested_antibodies:
-                        # HIGH_RES_WITH_SPLIT_1
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES_WITH_SPLIT))
+                # HIGH_RES_WITH_SPLIT_1
+                if _add_positive_tested_antibodies(positive_tested_antibodies,
+                                                   AntibodyMatchTypes.HIGH_RES_WITH_SPLIT,
+                                                   positive_matches):
                     continue
 
-                if hla_type.code.high_res is None:  # SPLIT_1
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.split == antibody.code.split
-                                                    if hla_type.code.split is not None]
-                else:  # SPLIT_2
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.split == antibody.code.split
-                                                    and antibody.code.high_res is None
-                                                    if hla_type.code.split is not None]
-                if len(tested_antibodies_that_match) > 0:
-                    for match in _get_antibodies_over_cutoff(tested_antibodies_that_match):
-                        # SPLIT_1, SPLIT_2
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.SPLIT))
+                if _add_split_typization(hla_type, tested_antibodies_that_match, positive_matches):
                     continue
 
             if hla_type.code.broad is not None:
@@ -149,47 +189,40 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                                                 if hla_type.code.broad == antibody.code.broad]
                 positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
 
-                if len(positive_tested_antibodies) > 0:
-                    if (hla_type.code.high_res is None
-                            and (len(tested_antibodies_that_match) == len(positive_tested_antibodies))):
-                        for match in tested_antibodies_that_match:
-                            # HIGH_RES_3
-                            positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES))
+                # HIGH_RES_3
+                if hla_type.code.high_res is None:
+                    if _add_all_tested_antibodies_are_positive(tested_antibodies_that_match,
+                                                               positive_tested_antibodies,
+                                                               AntibodyMatchTypes.HIGH_RES,
+                                                               positive_matches):
                         continue
 
-                    if hla_type.code.high_res is None and hla_type.code.split is None:
-                        for match in positive_tested_antibodies:
-                            # HIGH_RES_WITH_BROAD_1
-                            positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES_WITH_BROAD))
+                # HIGH_RES_WITH_BROAD_1
+                if hla_type.code.high_res is None and hla_type.code.split is None:
+                    if _add_positive_tested_antibodies(positive_tested_antibodies,
+                                                       AntibodyMatchTypes.HIGH_RES_WITH_BROAD,
+                                                       positive_matches):
                         continue
 
-                if hla_type.code.high_res is None and hla_type.code.split is None:  # BROAD_1
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.broad == antibody.code.broad]
-                else:  # BROAD_2
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.broad == antibody.code.broad
-                                                    if antibody.code.high_res is None and antibody.code.split is None]
-                if len(tested_antibodies_that_match) > 0:
-                    for match in _get_antibodies_over_cutoff(tested_antibodies_that_match):
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.BROAD))
+                if _add_broad_typization(hla_type, tested_antibodies_that_match, positive_matches):
                     continue
 
         _add_none_typization(_get_antibodies_over_cutoff(antibodies), positive_matches)
+
         antibody_matches_for_groups.append(AntibodyMatchForHLAGroup(hla_per_group.hla_group, positive_matches))
 
     return antibody_matches_for_groups
 
 
 def do_crossmatch_in_type_b(donor_hla_typing: HLATyping,
-                             recipient_antibodies: HLAAntibodies,
-                             use_high_resolution: bool) -> List[AntibodyMatchForHLAGroup]:
+                            recipient_antibodies: HLAAntibodies,
+                            use_high_resolution: bool) -> List[AntibodyMatchForHLAGroup]:
     antibody_matches_for_groups = []
 
     for hla_per_group, antibodies_per_group in zip(donor_hla_typing.hla_per_groups,
                                                    recipient_antibodies.hla_antibodies_per_groups):
         positive_matches = []
-        antibodies = _get_antibodies_over_cutoff(antibodies_per_group.hla_antibody_list)
+        antibodies = antibodies_per_group.hla_antibody_list
 
         _add_undecidable_typization(antibodies, hla_per_group, positive_matches)
 
@@ -197,42 +230,27 @@ def do_crossmatch_in_type_b(donor_hla_typing: HLATyping,
             if use_high_resolution and hla_type.code.high_res is not None:
                 tested_antibodies_that_match = [antibody for antibody in antibodies
                                                 if hla_type.code.high_res == antibody.code.high_res]
-                if len(tested_antibodies_that_match) > 0:
-                    for match in tested_antibodies_that_match:
-                        # HIGH_RES_1
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.HIGH_RES))
+                # HIGH_RES_1
+                if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                                   AntibodyMatchTypes.HIGH_RES,
+                                                   positive_matches):
                     continue
 
             if hla_type.code.split is not None:
-                if hla_type.code.high_res is None:  # SPLIT_1
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.split == antibody.code.split
-                                                    if hla_type.code.split is not None]
-                else:  # SPLIT_2
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.split == antibody.code.split
-                                                    and antibody.code.high_res is None
-                                                    if hla_type.code.split is not None]
-                if len(tested_antibodies_that_match) > 0:
-                    for match in tested_antibodies_that_match:
-                        # SPLIT_1, SPLIT_2
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.SPLIT))
+                tested_antibodies_that_match = [antibody for antibody in antibodies
+                                                if hla_type.code.split == antibody.code.split
+                                                if hla_type.code.split is not None]
+                if _add_split_typization(hla_type, tested_antibodies_that_match, positive_matches):
                     continue
 
             if hla_type.code.broad is not None:
-                if hla_type.code.high_res is None and hla_type.code.split is None:  # BROAD_1
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.broad == antibody.code.broad]
-                else:  # BROAD_2
-                    tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.broad == antibody.code.broad
-                                                    if antibody.code.high_res is None and antibody.code.split is None]
-                if len(tested_antibodies_that_match) > 0:
-                    for match in tested_antibodies_that_match:
-                        positive_matches.append(AntibodyMatch(match, AntibodyMatchTypes.BROAD))
+                tested_antibodies_that_match = [antibody for antibody in antibodies
+                                                if hla_type.code.broad == antibody.code.broad]
+                if _add_broad_typization(hla_type, tested_antibodies_that_match, positive_matches):
                     continue
 
         _add_none_typization(antibodies, positive_matches)
+
         antibody_matches_for_groups.append(AntibodyMatchForHLAGroup(hla_per_group.hla_group, positive_matches))
 
     return antibody_matches_for_groups
@@ -263,9 +281,13 @@ def get_crossmatched_antibodies(donor_hla_typing: HLATyping,
                                 recipient_antibodies: HLAAntibodies,
                                 use_high_resolution: bool):
     if is_recipient_type_a(recipient_antibodies):
-        antibody_matches_for_groups = do_crossmatch_in_type_a(donor_hla_typing, recipient_antibodies, use_high_resolution)
+        antibody_matches_for_groups = do_crossmatch_in_type_a(donor_hla_typing,
+                                                              recipient_antibodies,
+                                                              use_high_resolution)
     else:
-        antibody_matches_for_groups = do_crossmatch_in_type_b(donor_hla_typing, recipient_antibodies, use_high_resolution)
+        antibody_matches_for_groups = do_crossmatch_in_type_b(donor_hla_typing,
+                                                              recipient_antibodies,
+                                                              use_high_resolution)
 
     # Sort antibodies
     for antibodies_per_hla_group in antibody_matches_for_groups:
@@ -282,8 +304,7 @@ def is_positive_hla_crossmatch(donor_hla_typing: HLATyping,
                                recipient_antibodies: HLAAntibodies,
                                use_high_resolution: bool,
                                crossmatch_level: HLACrossmatchLevel = HLACrossmatchLevel.NONE,
-                               crossmatch_logic: Callable = get_crossmatched_antibodies
-                               ) -> bool:
+                               crossmatch_logic: Callable = get_crossmatched_antibodies) -> bool:
     """
     Do donor and recipient have positive crossmatch in HLA system?
     e.g. A23 -> A23 True
@@ -296,6 +317,7 @@ def is_positive_hla_crossmatch(donor_hla_typing: HLATyping,
     :param recipient_antibodies: recipient antibodies to crossmatch
     :param use_high_resolution: setting whether to high res resolution for crossmatch determination
     :param crossmatch_level:
+    :param crossmatch_logic:
     :return:
     """
     common_codes = {antibody_match.hla_antibody for antibody_match_group in

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -134,8 +134,12 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                                                    positive_matches):
                     continue
 
-                if _add_split_typization(hla_type, tested_antibodies_that_match, positive_matches):
-                    continue
+                # SPLIT_1
+                if hla_type.code.high_res is None:
+                    if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                                       AntibodyMatchTypes.SPLIT,
+                                                       positive_matches):
+                        continue
 
             if hla_type.code.broad is not None:
                 tested_antibodies_that_match = [antibody for antibody in antibodies
@@ -157,8 +161,12 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                                                        positive_matches):
                         continue
 
-                if _add_broad_typization(hla_type, tested_antibodies_that_match, positive_matches):
-                    continue
+                # BROAD_1
+                if hla_type.code.high_res is None and hla_type.code.split is None:
+                    if _add_positive_tested_antibodies(tested_antibodies_that_match,
+                                                       AntibodyMatchTypes.BROAD,
+                                                       positive_matches):
+                        continue
 
         _add_none_typization(_get_antibodies_over_cutoff(antibodies), positive_matches)
 

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -21,6 +21,57 @@ class AntibodyMatchForHLAGroup:
     antibody_matches: List[AntibodyMatch]
 
 
+def get_crossmatched_antibodies(donor_hla_typing: HLATyping,
+                                recipient_antibodies: HLAAntibodies,
+                                use_high_resolution: bool):
+    if is_recipient_type_a(recipient_antibodies):
+        antibody_matches_for_groups = do_crossmatch_in_type_a(donor_hla_typing,
+                                                              recipient_antibodies,
+                                                              use_high_resolution)
+    else:
+        antibody_matches_for_groups = do_crossmatch_in_type_b(donor_hla_typing,
+                                                              recipient_antibodies,
+                                                              use_high_resolution)
+
+    # Sort antibodies
+    for antibodies_per_hla_group in antibody_matches_for_groups:
+        antibodies_per_hla_group.antibody_matches = sorted(
+            antibodies_per_hla_group.antibody_matches,
+            key=lambda hla_group: (
+                hla_group.hla_antibody.raw_code,
+            ))
+
+    return antibody_matches_for_groups
+
+
+def is_positive_hla_crossmatch(donor_hla_typing: HLATyping,
+                               recipient_antibodies: HLAAntibodies,
+                               use_high_resolution: bool,
+                               crossmatch_level: HLACrossmatchLevel = HLACrossmatchLevel.NONE,
+                               crossmatch_logic: Callable = get_crossmatched_antibodies) -> bool:
+    """
+    Do donor and recipient have positive crossmatch in HLA system?
+    e.g. A23 -> A23 True
+         A9 -> A9  True
+         A23 -> A9 True
+         A23 -> A24 False if use_high_resolution else True
+         A9 -> A23 True
+         A9 broad <=> A23, A24 split
+    :param donor_hla_typing: donor hla_typing to crossmatch
+    :param recipient_antibodies: recipient antibodies to crossmatch
+    :param use_high_resolution: setting whether to high res resolution for crossmatch determination
+    :param crossmatch_level:
+    :param crossmatch_logic:
+    :return:
+    """
+    common_codes = {antibody_match.hla_antibody for antibody_match_group in
+                    crossmatch_logic(donor_hla_typing, recipient_antibodies, use_high_resolution)
+                    for antibody_match in antibody_match_group.antibody_matches
+                    if antibody_match.match_type.is_positive_for_level(crossmatch_level)}
+    # if there are any common codes, positive crossmatch is found
+    return len(common_codes) > 0
+
+
 def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                             recipient_antibodies: HLAAntibodies,
                             use_high_resolution: bool) -> List[AntibodyMatchForHLAGroup]:
@@ -177,57 +228,6 @@ def is_recipient_type_a(recipient_antibodies: HLAAntibodies) -> bool:
         return False
 
     return True
-
-
-def get_crossmatched_antibodies(donor_hla_typing: HLATyping,
-                                recipient_antibodies: HLAAntibodies,
-                                use_high_resolution: bool):
-    if is_recipient_type_a(recipient_antibodies):
-        antibody_matches_for_groups = do_crossmatch_in_type_a(donor_hla_typing,
-                                                              recipient_antibodies,
-                                                              use_high_resolution)
-    else:
-        antibody_matches_for_groups = do_crossmatch_in_type_b(donor_hla_typing,
-                                                              recipient_antibodies,
-                                                              use_high_resolution)
-
-    # Sort antibodies
-    for antibodies_per_hla_group in antibody_matches_for_groups:
-        antibodies_per_hla_group.antibody_matches = sorted(
-            antibodies_per_hla_group.antibody_matches,
-            key=lambda hla_group: (
-                hla_group.hla_antibody.raw_code,
-            ))
-
-    return antibody_matches_for_groups
-
-
-def is_positive_hla_crossmatch(donor_hla_typing: HLATyping,
-                               recipient_antibodies: HLAAntibodies,
-                               use_high_resolution: bool,
-                               crossmatch_level: HLACrossmatchLevel = HLACrossmatchLevel.NONE,
-                               crossmatch_logic: Callable = get_crossmatched_antibodies) -> bool:
-    """
-    Do donor and recipient have positive crossmatch in HLA system?
-    e.g. A23 -> A23 True
-         A9 -> A9  True
-         A23 -> A9 True
-         A23 -> A24 False if use_high_resolution else True
-         A9 -> A23 True
-         A9 broad <=> A23, A24 split
-    :param donor_hla_typing: donor hla_typing to crossmatch
-    :param recipient_antibodies: recipient antibodies to crossmatch
-    :param use_high_resolution: setting whether to high res resolution for crossmatch determination
-    :param crossmatch_level:
-    :param crossmatch_logic:
-    :return:
-    """
-    common_codes = {antibody_match.hla_antibody for antibody_match_group in
-                    crossmatch_logic(donor_hla_typing, recipient_antibodies, use_high_resolution)
-                    for antibody_match in antibody_match_group.antibody_matches
-                    if antibody_match.match_type.is_positive_for_level(crossmatch_level)}
-    # if there are any common codes, positive crossmatch is found
-    return len(common_codes) > 0
 
 
 def _get_antibodies_over_cutoff(antibodies: List[HLAAntibody]) -> List[HLAAntibody]:

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -7,6 +7,9 @@ from txmatching.utils.enums import (AntibodyMatchTypes, HLACrossmatchLevel,
                                     HLAGroup)
 
 
+MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A = 20
+
+
 @dataclass(eq=True, frozen=True)
 class AntibodyMatch:
     hla_antibody: HLAAntibody
@@ -226,7 +229,7 @@ def _is_recipient_type_a(recipient_antibodies: HLAAntibodies) -> bool:
             if hla_antibody.mfi < hla_antibody.cutoff:
                 is_at_least_one_antibody_below_cutoff = True
 
-    if total_antibodies < 5:
+    if total_antibodies < MINIMUM_REQUIRED_ANTIBODIES_FOR_TYPE_A:
         return False
 
     if is_at_least_one_antibody_below_cutoff:

--- a/txmatching/utils/hla_system/hla_crossmatch.py
+++ b/txmatching/utils/hla_system/hla_crossmatch.py
@@ -85,7 +85,8 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
                     continue
 
                 tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                if hla_type.code.split == antibody.code.split]
+                                                if hla_type.code.split == antibody.code.split
+                                                if hla_type.code.split is not None]
                 positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
 
                 if len(positive_tested_antibodies) > 0:
@@ -102,7 +103,8 @@ def do_crossmatch_in_type_a(donor_hla_typing: HLATyping,
 
             if hla_type.code.split is not None:
                 tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                if hla_type.code.split == antibody.code.split]
+                                                if hla_type.code.split == antibody.code.split
+                                                if hla_type.code.split is not None]
                 positive_tested_antibodies = _get_antibodies_over_cutoff(tested_antibodies_that_match)
 
                 if len(positive_tested_antibodies) > 0:
@@ -168,11 +170,13 @@ def do_crossmatch_in_type_b(donor_hla_typing: HLATyping,
             if hla_type.code.split is not None:
                 if hla_type.code.high_res is None:  # SPLIT_1
                     tested_antibodies_that_match = [antibody for antibody in antibodies
-                                                    if hla_type.code.split == antibody.code.split]
+                                                    if hla_type.code.split == antibody.code.split
+                                                    if hla_type.code.split is not None]
                 else:  # SPLIT_2
                     tested_antibodies_that_match = [antibody for antibody in antibodies
                                                     if hla_type.code.split == antibody.code.split
-                                                    and antibody.code.high_res is None]
+                                                    and antibody.code.high_res is None
+                                                    if hla_type.code.split is not None]
                 if len(tested_antibodies_that_match) > 0:
                     for match in tested_antibodies_that_match:
                         # SPLIT_1, SPLIT_2


### PR DESCRIPTION
Hello there, I've
1. divided the crossmatching into seperated types
2. added https://github.com/mild-blue/txmatching/blob/4f4dcb0b00f258405084d7837628d3aaac648b0f/txmatching/utils/hla_system/hla_crossmatch.py#L125 because of not getting antibodies below cutoff in https://github.com/mild-blue/txmatching/blob/4f4dcb0b00f258405084d7837628d3aaac648b0f/txmatching/utils/hla_system/hla_crossmatch.py#L142-L145
3. removed https://github.com/mild-blue/txmatching/blob/06f545e00f9eb31fb0c46a79b73d87cf0c6584cf/txmatching/utils/hla_system/hla_crossmatch.py#L82 from the logic code and modified https://github.com/mild-blue/txmatching/blob/06f545e00f9eb31fb0c46a79b73d87cf0c6584cf/tests/web/test_patient_api.py#L523 to https://github.com/mild-blue/txmatching/blob/4f4dcb0b00f258405084d7837628d3aaac648b0f/tests/web/test_patient_api.py#L523 to check the uniqueness of antibodies.

What are you thoughts?