### PR TITLE
Update add-issue-to-project.yml

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,4 +1,4 @@
-name: Add new issue to project
+name: Add issue to project
 
 on:
   issues:
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v3.0.0
+      - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/mild-blue/projects/27
           github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT_PAT }}


### PR DESCRIPTION
Podle tohoto to vypadá, že byla použita špatná verze ve workflow souboru:
![image](https://user-images.githubusercontent.com/79165095/195156990-668c999b-0bd4-4f15-baeb-6dd2cdbde135.png)

Podle https://github.com/actions/add-to-project je aktuální verze `0.3.0`.

Taky jsem nastavil, že nová issue se automaticky vloží do:
![image](https://user-images.githubusercontent.com/79165095/195157738-218b2b0b-548b-42c2-af18-2e7e85c00d9b.png)

Nemám ale tušení, jak tohle otestovat.

P.S. Poprosím o smazání https://github.com/mild-blue/txmatching/issues/1024.