### PR TITLE
feat: add forgiving option to HLA parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,10 @@ Crossmatch happens because of a match of the recipient's antibody with the donor
 There are six types of crossmatches. You will be able to read about them in the future in [TXM knowledge base](documentation/README.md).
 
 To generate patients with crossmatches warnings set parameter CROSSMATCH to True in `__main__` function in generate_patients.py
+
+### HLA Parsing Strictness
+In the txm event attributes, there is an attribute called "strictness_type" that can be set to either "STRICT" or "FORGIVING".
+
+STRICT = normal parsing, no exceptions being made.
+
+FORGIVING = some parsing errors and warnings are overlooked for the sake of including recipients in a matching. It is used especially when we need to parse data from other KEPs that recognize different set of HLAs.

--- a/local_testing_utilities/utils.py
+++ b/local_testing_utilities/utils.py
@@ -1,6 +1,6 @@
 from txmatching.database.db import db
 from txmatching.database.sql_alchemy_schema import TxmEventModel
-from txmatching.patients.patient import TxmEvent, StrictnessType
+from txmatching.patients.patient import StrictnessType, TxmEvent
 
 
 def create_or_overwrite_txm_event(name: str, strictness_type: StrictnessType = StrictnessType.STRICT) -> TxmEvent:

--- a/local_testing_utilities/utils.py
+++ b/local_testing_utilities/utils.py
@@ -1,17 +1,17 @@
 from txmatching.database.db import db
 from txmatching.database.sql_alchemy_schema import TxmEventModel
-from txmatching.patients.patient import TxmEvent
+from txmatching.patients.patient import TxmEvent, StrictnessType
 
 
-def create_or_overwrite_txm_event(name: str) -> TxmEvent:
+def create_or_overwrite_txm_event(name: str, strictness_type: StrictnessType = StrictnessType.STRICT) -> TxmEvent:
     previous_txm_model = TxmEventModel.query.filter(TxmEventModel.name == name).first()
     if previous_txm_model:
         db.session.delete(previous_txm_model)
         db.session.flush()
-    txm_event_model = TxmEventModel(name=name)
+    txm_event_model = TxmEventModel(name=name, strictness_type=strictness_type)
     db.session.add(txm_event_model)
     db.session.commit()
     return TxmEvent(db_id=txm_event_model.id, name=txm_event_model.name,
                     default_config_id=txm_event_model.default_config_id,
-                    state=txm_event_model.state,
+                    state=txm_event_model.state, strictness_type=strictness_type,
                     all_donors=[], all_recipients=[])

--- a/tests/database/services/test_patient_service.py
+++ b/tests/database/services/test_patient_service.py
@@ -27,7 +27,7 @@ from txmatching.database.sql_alchemy_schema import (ConfigModel, DonorModel,
 from txmatching.patients.patient import DonorType, TxmEvent
 from txmatching.utils.blood_groups import BloodGroup
 from txmatching.utils.country_enum import Country
-from txmatching.utils.enums import Sex, TxmEventState
+from txmatching.utils.enums import Sex, StrictnessType, TxmEventState
 from txmatching.utils.logged_user import get_current_user_id
 
 TXM_EVENT_NAME = 'test'
@@ -227,7 +227,7 @@ class TestPatientService(DbTests):
 
     def test_get_patients_hash(self):
         txm_event_1 = TxmEvent(
-            1, 'event_name_1', None, TxmEventState.OPEN,
+            1, 'event_name_1', None, TxmEventState.OPEN, StrictnessType.STRICT,
             all_donors=get_test_donors(),
             all_recipients=get_test_recipients()
         )
@@ -236,7 +236,7 @@ class TestPatientService(DbTests):
 
         # changing event db id or event name does not change the hash
         txm_event_2 = TxmEvent(
-            2, 'event_name_2', None, TxmEventState.OPEN,
+            2, 'event_name_2', None, TxmEventState.OPEN, StrictnessType.STRICT,
             all_donors=get_test_donors(),
             all_recipients=get_test_recipients()
         )
@@ -245,7 +245,7 @@ class TestPatientService(DbTests):
 
         # Changing donors changes the hash
         txm_event_3 = TxmEvent(
-            1, 'event_name_1', None, TxmEventState.OPEN,
+            1, 'event_name_1', None, TxmEventState.OPEN, StrictnessType.STRICT,
             all_donors=[],
             all_recipients=get_test_recipients()
         )
@@ -254,7 +254,7 @@ class TestPatientService(DbTests):
 
         # Changing recipients changes the hash
         txm_event_4 = TxmEvent(
-            1, 'event_name_1', None, TxmEventState.OPEN,
+            1, 'event_name_1', None, TxmEventState.OPEN, StrictnessType.STRICT,
             all_donors=get_test_donors(),
             all_recipients=[]
         )
@@ -270,7 +270,7 @@ class TestPatientService(DbTests):
         new_donors[0].parameters.hla_typing.hla_per_groups[0].hla_types[0] = create_hla_type('A3')
 
         txm_event_5 = TxmEvent(
-            1, 'event_name_1', None, TxmEventState.OPEN,
+            1, 'event_name_1', None, TxmEventState.OPEN, StrictnessType.STRICT,
             all_donors=new_donors,
             all_recipients=get_test_recipients()
         )

--- a/tests/database/services/test_update_donor_recipient.py
+++ b/tests/database/services/test_update_donor_recipient.py
@@ -101,7 +101,7 @@ class TestUpdateDonorRecipient(DbTests):
                              hla_type in
                              hla_group['hla_types']})
 
-        txm_event_base = get_txm_event_complete(txm_event_db_id)
+        txm_event_base = get_txm_event_base(txm_event_db_id)
         update_donor(DonorUpdateDTO(
             hla_typing=HLATypingUpdateDTO([
                 HLATypeUpdateDTO('A11'),

--- a/tests/utils/hla_system/test_code_parser.py
+++ b/tests/utils/hla_system/test_code_parser.py
@@ -93,12 +93,9 @@ codes_forgiving_parsing = {
     'A*68:06': (HLACode('A*68:06', 'A68', 'A28'), ParsingIssueDetail.FORGIVING_HLA_PARSING),
     'B*46:10': (HLACode('B*46:10', 'B46', 'B46'), ParsingIssueDetail.FORGIVING_HLA_PARSING),
     'A*02:719': (HLACode('A*02:719', 'A2', 'A2'), ParsingIssueDetail.FORGIVING_HLA_PARSING),
-    'B*83': (HLACode(None, 'B83', 'B83'), ParsingIssueDetail.SUCCESSFULLY_PARSED),
-    'B83': (HLACode(None, 'B83', 'B83'), ParsingIssueDetail.SUCCESSFULLY_PARSED),
-    'C1': (HLACode(None, 'CW1', 'CW1'), ParsingIssueDetail.SUCCESSFULLY_PARSED),
-    'DPB13': (HLACode(None, 'DP13', 'DP13'), ParsingIssueDetail.SUCCESSFULLY_PARSED),
-    'A9': (HLACode(None, None, 'A9'), ParsingIssueDetail.SUCCESSFULLY_PARSED),
-    'A23': (HLACode(None, 'A23', 'A9'), ParsingIssueDetail.SUCCESSFULLY_PARSED)
+    'A*33:02': (HLACode('A*33:02', None, None), ParsingIssueDetail.FORGIVING_HLA_PARSING),
+    'CW70': (HLACode(None, 'CW70', 'CW70'), ParsingIssueDetail.FORGIVING_HLA_PARSING),
+    'B6': (HLACode(None, 'B6', 'B6'), ParsingIssueDetail.FORGIVING_HLA_PARSING)
 }
 
 class TestCodeParser(DbTests):

--- a/tests/utils/hla_system/test_code_parser.py
+++ b/tests/utils/hla_system/test_code_parser.py
@@ -332,7 +332,7 @@ class TestCodeParser(DbTests):
         self.assertEqual(expected,
                          analyze_if_high_res_antibodies_are_type_a(some_antibodies_list))
 
-        expected = HighResAntibodiesAnalysis(True, None)
+        expected = HighResAntibodiesAnalysis(True, ParsingIssueDetail.FORGIVING_HLA_PARSING)
         self.assertEqual(expected,
                          analyze_if_high_res_antibodies_are_type_a(some_antibodies_list,
                                                                    strictness_type=StrictnessType.FORGIVING))

--- a/tests/utils/test_matching.py
+++ b/tests/utils/test_matching.py
@@ -77,33 +77,33 @@ class TestMatching(DbTests):
 
         # A32
         result = calculate_compatibility_index_for_group(donors[0], recipients[0], HLAGroup.A)
-        self.assertEquals(1, result)
+        self.assertEqual(1, result)
 
         result = calculate_compatibility_index_for_group(donors[0], recipients[0], HLAGroup.B)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
         result = calculate_compatibility_index_for_group(donors[0], recipients[0], HLAGroup.DRB1)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
         # No match
         result = calculate_compatibility_index_for_group(donors[0], recipients[1], HLAGroup.A)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
         result = calculate_compatibility_index_for_group(donors[0], recipients[1], HLAGroup.B)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
         result = calculate_compatibility_index_for_group(donors[0], recipients[1], HLAGroup.DRB1)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
         # A32, B7
         result = calculate_compatibility_index_for_group(donors[1], recipients[0], HLAGroup.A)
-        self.assertEquals(2, result)
+        self.assertEqual(2, result)
 
         result = calculate_compatibility_index_for_group(donors[1], recipients[0], HLAGroup.B)
-        self.assertEquals(6, result)
+        self.assertEqual(6, result)
 
         result = calculate_compatibility_index_for_group(donors[1], recipients[0], HLAGroup.DRB1)
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
     def test_get_count_of_transplants(self):
         donors = get_test_donors()

--- a/txmatching/data_transfer_objects/enums_swagger.py
+++ b/txmatching/data_transfer_objects/enums_swagger.py
@@ -1,4 +1,4 @@
-from txmatching.patients.patient import DonorType
+from txmatching.patients.patient import DonorType, StrictnessType
 from txmatching.utils.blood_groups import BloodGroup
 from txmatching.utils.country_enum import Country
 from txmatching.utils.enums import (HLACrossmatchLevel, Scorer, Sex, Solver,
@@ -25,6 +25,12 @@ DonorTypeEnumJson = enums_api.schema_model('DonorType', {
     'enum': [donor_type.value for donor_type in DonorType],
     'type': 'string',
     'description': 'Type of the donor.'
+})
+
+StrictnessTypeEnumJson = enums_api.schema_model('StrictnessType', {
+    'enum': [strictness_type.value for strictness_type in StrictnessType],
+    'type': 'string',
+    'description': 'Level of strictness for HLA parsing.'
 })
 
 ScorerEnumJson = enums_api.schema_model('Scorer', {

--- a/txmatching/data_transfer_objects/external_patient_upload/swagger.py
+++ b/txmatching/data_transfer_objects/external_patient_upload/swagger.py
@@ -3,7 +3,7 @@ from flask_restx import fields
 
 from txmatching.data_transfer_objects.base_patient_swagger import (
     NewDonor, NewPatient, NewRecipient)
-from txmatching.data_transfer_objects.enums_swagger import CountryCodeJson
+from txmatching.data_transfer_objects.enums_swagger import CountryCodeJson, StrictnessTypeEnumJson
 from txmatching.data_transfer_objects.hla.parsing_issue_swagger import \
     ParsingIssuePublicJson
 from txmatching.web.web_utils.namespaces import public_api
@@ -39,7 +39,8 @@ UploadPatientsJson = public_api.model(
                                                    description='If *true* the currently uploaded patients will be added'
                                                                ' to the patients already in the system. If *false* the'
                                                                ' data in the system will be overwritten by the'
-                                                               ' currently uploaded data.')
+                                                               ' currently uploaded data.'),
+        'strictness_type': fields.Nested(StrictnessTypeEnumJson, required=False)
     }
 )
 

--- a/txmatching/data_transfer_objects/patients/txm_event_dto_in.py
+++ b/txmatching/data_transfer_objects/patients/txm_event_dto_in.py
@@ -6,18 +6,20 @@ from txmatching.database.services.patient_service import \
 from txmatching.database.services.txm_event_service import \
     raise_error_if_txm_event_does_not_exist
 from txmatching.utils.country_enum import Country
-from txmatching.utils.enums import TxmEventState
+from txmatching.utils.enums import StrictnessType, TxmEventState
 
 
 @dataclass
 class TxmEventDTOIn:
     name: str
+    strictness_type: StrictnessType = StrictnessType.STRICT
 
 
 @dataclass
 class TxmDefaultEventDTOIn:
     # pylint:disable=invalid-name
     id: int
+
     # pylint:enable=invalid-name
 
     def __post_init__(self):

--- a/txmatching/data_transfer_objects/patients/txm_event_dto_in.py
+++ b/txmatching/data_transfer_objects/patients/txm_event_dto_in.py
@@ -12,7 +12,7 @@ from txmatching.utils.enums import StrictnessType, TxmEventState
 @dataclass
 class TxmEventDTOIn:
     name: str
-    strictness_type: StrictnessType = StrictnessType.STRICT
+    strictness_type: Optional[StrictnessType] = StrictnessType.STRICT
 
 
 @dataclass
@@ -35,6 +35,7 @@ class TxmEventUpdateDTOIn:
 class TxmEventExportDTOIn:
     country: Country
     new_txm_event_name: str
+    strictness_type: Optional[StrictnessType] = StrictnessType.STRICT
 
 
 @dataclass

--- a/txmatching/data_transfer_objects/patients/txm_event_dto_out.py
+++ b/txmatching/data_transfer_objects/patients/txm_event_dto_out.py
@@ -12,7 +12,7 @@ class TxmEventDTOOut:
     name: str
     default_config_id: Optional[int]
     state: TxmEventState
-    strictness_type: StrictnessType
+    strictness_type: Optional[StrictnessType] = StrictnessType.STRICT
 
 
 @dataclass

--- a/txmatching/data_transfer_objects/patients/txm_event_dto_out.py
+++ b/txmatching/data_transfer_objects/patients/txm_event_dto_out.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from txmatching.utils.enums import TxmEventState
+from txmatching.utils.enums import StrictnessType, TxmEventState
 
 
 @dataclass
@@ -12,6 +12,7 @@ class TxmEventDTOOut:
     name: str
     default_config_id: Optional[int]
     state: TxmEventState
+    strictness_type: StrictnessType
 
 
 @dataclass

--- a/txmatching/data_transfer_objects/patients/upload_dtos/patient_upload_dto_in.py
+++ b/txmatching/data_transfer_objects/patients/upload_dtos/patient_upload_dto_in.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from txmatching.data_transfer_objects.patients.upload_dtos.donor_upload_dto import \
     DonorUploadDTO
 from txmatching.data_transfer_objects.patients.upload_dtos.recipient_upload_dto import \
     RecipientUploadDTO
 from txmatching.utils.country_enum import Country
-
+from txmatching.utils.enums import StrictnessType
 
 @dataclass
 class PatientUploadDTOIn:
@@ -15,3 +15,4 @@ class PatientUploadDTOIn:
     donors: List[DonorUploadDTO]
     recipients: List[RecipientUploadDTO]
     add_to_existing_patients: bool = False
+    strictness_type: Optional[StrictnessType] = StrictnessType.STRICT

--- a/txmatching/data_transfer_objects/patients/upload_dtos/patient_upload_dto_in.py
+++ b/txmatching/data_transfer_objects/patients/upload_dtos/patient_upload_dto_in.py
@@ -8,6 +8,7 @@ from txmatching.data_transfer_objects.patients.upload_dtos.recipient_upload_dto 
 from txmatching.utils.country_enum import Country
 from txmatching.utils.enums import StrictnessType
 
+
 @dataclass
 class PatientUploadDTOIn:
     country: Country

--- a/txmatching/data_transfer_objects/txm_event/txm_event_swagger.py
+++ b/txmatching/data_transfer_objects/txm_event/txm_event_swagger.py
@@ -1,13 +1,15 @@
 from flask_restx import fields
 
 from txmatching.data_transfer_objects.enums_swagger import (CountryCodeJson,
+                                                            StrictnessTypeEnumJson,
                                                             TxmEventStateJson)
 from txmatching.data_transfer_objects.hla.parsing_issue_swagger import \
     ParsingIssueJson
 from txmatching.web.web_utils.namespaces import txm_event_api
 
 TxmEventJsonIn = txm_event_api.model('NewTxmEvent', {
-    'name': fields.String(required=True)
+    'name': fields.String(required=True),
+    'strictness_type': fields.Nested(StrictnessTypeEnumJson, required=False)
 })
 
 TxmDefaultEventJsonIn = txm_event_api.model('DefaultTxmEvent', {
@@ -19,6 +21,7 @@ TxmEventJsonOut = txm_event_api.model('TxmEvent', {
     'name': fields.String(required=True),
     'default_config_id': fields.Integer(required=False),
     'state': fields.Nested(TxmEventStateJson, required=True),
+    'strictness_type': fields.Nested(StrictnessTypeEnumJson, required=True)
 })
 
 PatientsRecomputeParsingSuccessJson = txm_event_api.model('PatientsRecomputeParsingSuccess', {

--- a/txmatching/data_transfer_objects/txm_event/txm_event_swagger.py
+++ b/txmatching/data_transfer_objects/txm_event/txm_event_swagger.py
@@ -44,7 +44,8 @@ TxmEventUpdateJsonIn = txm_event_api.model('TxmEventUpdateIn', {
 
 TxmEventExportJsonIn = txm_event_api.model('TxmEventExport', {
     'country': fields.Nested(CountryCodeJson, required=True),
-    'new_txm_event_name': fields.String(required=True)
+    'new_txm_event_name': fields.String(required=True),
+    'strictness_type': fields.Nested(StrictnessTypeEnumJson, required=False)
 })
 
 TxmEventCopyPatientsJsonIn = txm_event_api.model('TxmEventCopy', {

--- a/txmatching/database/db_migrations/0036.add-attribute-to-txm-event-base.sql
+++ b/txmatching/database/db_migrations/0036.add-attribute-to-txm-event-base.sql
@@ -1,0 +1,12 @@
+--
+-- file: txmatching/database/db_migrations/0036.add-attribute-to-txm-event-base.sql
+-- depends: 0035.add-new-parsing-issue-detail
+--
+
+CREATE TYPE STRICTNESS_TYPE AS ENUM (
+    'STRICT',
+    'FORGIVING'
+    );
+
+ALTER TABLE txm_event ADD COLUMN strictness_type STRICTNESS_TYPE NOT NULL default 'STRICT';
+ALTER TYPE PARSING_ISSUE_DETAIL ADD VALUE 'FORGIVING_HLA_PARSING';

--- a/txmatching/database/services/patient_upload_service.py
+++ b/txmatching/database/services/patient_upload_service.py
@@ -206,7 +206,7 @@ def _donor_upload_dto_to_donor_model(
             maybe_related_recipient is None):
         raise InvalidArgumentException(
             f'Donor (medical id "{donor.medical_id}") has related recipient (medical id '
-            f'"{donor.related_recipient_medical_id}"), which was not found among recipients in txm event {txm_event_db_id}.'
+            f'"{donor.related_recipient_medical_id}"), which was not found among recipients in txm event {txm_event_base.db_id}.'
         )
 
     if donor.donor_type != DonorType.DONOR and donor.related_recipient_medical_id is not None:

--- a/txmatching/database/services/txm_event_service.py
+++ b/txmatching/database/services/txm_event_service.py
@@ -20,7 +20,7 @@ from txmatching.database.sql_alchemy_schema import (AppUserModel, DonorModel,
                                                     TxmEventModel,
                                                     UploadedDataModel,
                                                     UserToAllowedEvent)
-from txmatching.patients.patient import TxmEvent, TxmEventBase
+from txmatching.patients.patient import StrictnessType, TxmEvent, TxmEventBase
 from txmatching.utils.country_enum import Country
 from txmatching.utils.enums import TxmEventState
 from txmatching.utils.logged_user import get_current_user, get_current_user_id
@@ -36,15 +36,16 @@ def get_newest_txm_event_db_id() -> int:
         raise ValueError('There are no TXM events in the database.')
 
 
-def create_txm_event(name: str) -> TxmEvent:
+def create_txm_event(name: str, strictness_type: StrictnessType) -> TxmEvent:
     if len(TxmEventModel.query.filter(TxmEventModel.name == name).all()) > 0:
         raise InvalidArgumentException(f'TXM event "{name}" already exists.')
-    txm_event_model = TxmEventModel(name=name)
+    txm_event_model = TxmEventModel(name=name, strictness_type=strictness_type)
     db.session.add(txm_event_model)
     db.session.commit()
     return TxmEvent(db_id=txm_event_model.id, name=txm_event_model.name,
                     default_config_id=txm_event_model.default_config_id,
-                    state=TxmEventState.OPEN, all_donors=[], all_recipients=[])
+                    state=TxmEventState.OPEN, strictness_type=txm_event_model.strictness_type,
+                    all_donors=[], all_recipients=[])
 
 
 def delete_txm_event(txm_event_id: int):
@@ -160,7 +161,7 @@ def get_txm_event_base(txm_event_db_id: int) -> TxmEventBase:
 def _get_txm_event_base_from_txm_event_model(txm_event_model: TxmEventModel) -> TxmEventBase:
     return TxmEventBase(db_id=txm_event_model.id, name=txm_event_model.name,
                         default_config_id=txm_event_model.default_config_id,
-                        state=txm_event_model.state)
+                        state=txm_event_model.state, strictness_type=txm_event_model.strictness_type)
 
 
 def _get_txm_event_from_txm_event_model(txm_event_model: TxmEventModel) -> TxmEvent:
@@ -182,6 +183,7 @@ def _get_txm_event_from_txm_event_model(txm_event_model: TxmEventModel) -> TxmEv
                     name=txm_event_model.name,
                     default_config_id=txm_event_model.default_config_id,
                     state=TxmEventState.OPEN,
+                    strictness_type=txm_event_model.strictness_type,
                     all_donors=all_donors,
                     all_recipients=all_recipients)
 
@@ -236,7 +238,8 @@ def convert_txm_event_base_to_dto(txm_event_base: TxmEventBase) -> TxmEventDTOOu
         id=txm_event_base.db_id,
         name=txm_event_base.name,
         default_config_id=txm_event_base.default_config_id,
-        state=txm_event_base.state
+        state=txm_event_base.state,
+        strictness_type=txm_event_base.strictness_type
     )
 
 

--- a/txmatching/database/services/txm_event_service.py
+++ b/txmatching/database/services/txm_event_service.py
@@ -36,7 +36,7 @@ def get_newest_txm_event_db_id() -> int:
         raise ValueError('There are no TXM events in the database.')
 
 
-def create_txm_event(name: str, strictness_type: StrictnessType) -> TxmEvent:
+def create_txm_event(name: str, strictness_type: StrictnessType = StrictnessType.STRICT) -> TxmEvent:
     if len(TxmEventModel.query.filter(TxmEventModel.name == name).all()) > 0:
         raise InvalidArgumentException(f'TXM event "{name}" already exists.')
     txm_event_model = TxmEventModel(name=name, strictness_type=strictness_type)

--- a/txmatching/database/sql_alchemy_schema.py
+++ b/txmatching/database/sql_alchemy_schema.py
@@ -10,7 +10,7 @@ from sqlalchemy.types import (BIGINT, BLOB, BOOLEAN, DATETIME, FLOAT, INTEGER,
 
 from txmatching.auth.data_types import UserRole
 from txmatching.database.db import db
-from txmatching.patients.patient import DonorType, RecipientRequirements
+from txmatching.patients.patient import DonorType, RecipientRequirements, StrictnessType
 from txmatching.utils.blood_groups import BloodGroup
 from txmatching.utils.country_enum import Country
 # pylint: disable=too-few-public-methods,too-many-arguments
@@ -27,7 +27,7 @@ class ConfigModel(db.Model):
     # transferred to BigSerial with autoincrement True, but to BigInt only.
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     parameters = Column(JSON, unique=False, nullable=False)
     created_by = Column(INTEGER, ForeignKey('app_user.id'), unique=False, nullable=False)
     # created at and updated at is not handled by triggers as then am not sure how tests would work, as triggers
@@ -43,7 +43,7 @@ class PairingResultModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     original_config_id = Column(INTEGER, ForeignKey('config.id', onupdate='CASCADE',
-                                ondelete='CASCADE'), unique=False, nullable=False)
+                                                    ondelete='CASCADE'), unique=False, nullable=False)
     original_config = relationship('ConfigModel', passive_deletes=True, lazy='joined')
     patients_hash = Column(BIGINT, unique=False, nullable=False)
     calculated_matchings = Column(JSON, unique=False, nullable=False)
@@ -66,6 +66,7 @@ class TxmEventModel(db.Model):
     # work otherwise (no such table: main.txm_event)
     default_config_id = Column(BIGINT, unique=False, nullable=True)
     state = Column(Enum(TxmEventState), unique=False, nullable=False, default=TxmEventState.OPEN)
+    strictness_type = Column(Enum(StrictnessType), unique=False, nullable=False)
     donors = relationship('DonorModel', backref='txm_event', passive_deletes=True)  # type: List[DonorModel]
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
@@ -78,7 +79,7 @@ class RecipientModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
@@ -117,7 +118,7 @@ class DonorModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     medical_id = Column(TEXT, unique=False, nullable=False)
     internal_medical_id = Column(TEXT, unique=False, nullable=True)
     country = Column(Enum(Country), unique=False, nullable=False)
@@ -135,7 +136,7 @@ class DonorModel(db.Model):
     updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
     deleted_at = Column(DATETIME(timezone=True), nullable=True)
     recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=True)
+                                              ondelete='CASCADE'), unique=False, nullable=True)
     recipient = relationship('RecipientModel', backref=backref('donor', uselist=False),
                              passive_deletes=True,
                              lazy='joined')
@@ -153,7 +154,7 @@ class RecipientAcceptableBloodModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     blood_type = Column(Enum(BloodGroup, values_callable=lambda x: [e.value for e in x]), unique=False, nullable=False)
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(DATETIME(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
@@ -166,7 +167,7 @@ class HLAAntibodyRawModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     recipient_id = Column(INTEGER, ForeignKey('recipient.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     raw_code = Column(TEXT, unique=False, nullable=False)
     mfi = Column(INTEGER, unique=False, nullable=False)
     cutoff = Column(INTEGER, unique=False, nullable=False)
@@ -188,7 +189,7 @@ class AppUserModel(db.Model):
     pass_hash = Column(TEXT, unique=False, nullable=False)
     role = Column(Enum(UserRole), unique=False, nullable=False)
     default_txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                                  ondelete='SET NULL'), unique=False, nullable=True)
+                                                      ondelete='SET NULL'), unique=False, nullable=True)
     # Whitelisted IP address if role is SERVICE
     # Seed for TOTP in all other cases
     second_factor_material = Column(TEXT, unique=False, nullable=False)
@@ -224,9 +225,9 @@ class UploadedDataModel(db.Model):
 
     id = Column(INTEGER, primary_key=True, autoincrement=True, nullable=False)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     user_id = Column(INTEGER, ForeignKey('app_user.id', onupdate='CASCADE',
-                     ondelete='CASCADE'), unique=False, nullable=False)
+                                         ondelete='CASCADE'), unique=False, nullable=False)
     uploaded_data = Column(JSON, unique=False, nullable=False)
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now(),
@@ -244,12 +245,12 @@ class ParsingIssueModel(db.Model):
     message = Column(TEXT, unique=False, default='')
     donor_id = Column(INTEGER, ForeignKey('donor.id', ondelete='CASCADE'), CheckConstraint(
         'donor_id IS NOT NULL OR recipient_id IS NOT NULL'),
-        unique=False,
-        nullable=True)
+                      unique=False,
+                      nullable=True)
     recipient_id = Column(INTEGER, ForeignKey('recipient.id', ondelete='CASCADE'), CheckConstraint(
         'donor_id IS NOT NULL OR recipient_id IS NOT NULL'),
-        unique=False,
-        nullable=True)
+                          unique=False,
+                          nullable=True)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', ondelete='CASCADE'), unique=False, nullable=False)
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(
@@ -272,9 +273,9 @@ class UploadedFileModel(db.Model):
     file_name = Column(TEXT, unique=False, nullable=False)
     file = Column(BLOB, unique=False, nullable=False)
     txm_event_id = Column(INTEGER, ForeignKey('txm_event.id', onupdate='CASCADE',
-                          ondelete='CASCADE'), unique=False, nullable=False)
+                                              ondelete='CASCADE'), unique=False, nullable=False)
     user_id = Column(INTEGER, ForeignKey('app_user.id', onupdate='CASCADE',
-                     ondelete='CASCADE'), unique=False, nullable=False)
+                                         ondelete='CASCADE'), unique=False, nullable=False)
     created_at = Column(DATETIME(timezone=True), unique=False, nullable=False, server_default=func.now())
     updated_at = Column(
         DATETIME(timezone=True),

--- a/txmatching/patients/hla_functions.py
+++ b/txmatching/patients/hla_functions.py
@@ -186,4 +186,6 @@ def analyze_if_high_res_antibodies_are_type_a(
     elif is_some_antibody_below_cutoff and len(recipient_antibodies) < SUFFICIENT_NUMBER_OF_ANTIBODIES_IN_HIGH_RES:
         return HighResAntibodiesAnalysis(False,
                                          ParsingIssueDetail.INSUFFICIENT_NUMBER_OF_ANTIBODIES_IN_HIGH_RES)
+    elif strictness_type == StrictnessType.FORGIVING:
+        return HighResAntibodiesAnalysis(True, ParsingIssueDetail.FORGIVING_HLA_PARSING)
     return HighResAntibodiesAnalysis(True, None)

--- a/txmatching/patients/hla_functions.py
+++ b/txmatching/patients/hla_functions.py
@@ -12,7 +12,7 @@ from txmatching.utils.constants import \
     SUFFICIENT_NUMBER_OF_ANTIBODIES_IN_HIGH_RES
 from txmatching.utils.enums import (GENE_HLA_GROUPS_WITH_OTHER,
                                     HLA_GROUPS_OTHER, HLA_GROUPS_PROPERTIES,
-                                    HLAGroup)
+                                    HLAGroup, StrictnessType)
 from txmatching.utils.hla_system.hla_transformations.get_mfi_from_multiple_hla_codes import \
     get_mfi_from_multiple_hla_codes
 from txmatching.utils.hla_system.hla_transformations.parsing_issue_detail import \
@@ -135,8 +135,8 @@ def _is_hla_type_in_group(hla_type: HLACodeAlias, hla_group: HLAGroup) -> bool:
 
 
 def _split_hla_types_to_groups(hla_types: List[HLACodeAlias]) -> Tuple[List[ParsingIssueBase], Dict[HLAGroup,
-                                                                                                    List[
-                                                                                                        HLACodeAlias]]]:
+List[
+    HLACodeAlias]]]:
     parsing_issues = []
     hla_types_in_groups = {}
     for hla_group in GENE_HLA_GROUPS_WITH_OTHER:
@@ -170,7 +170,8 @@ def is_all_antibodies_in_high_res(recipient_antibodies: List[HLAAntibody]) -> bo
 
 
 def analyze_if_high_res_antibodies_are_type_a(
-        recipient_antibodies: List[HLAAntibody]) -> HighResAntibodiesAnalysis:
+        recipient_antibodies: List[HLAAntibody],
+        strictness_type: StrictnessType = StrictnessType.STRICT) -> HighResAntibodiesAnalysis:
     assert is_all_antibodies_in_high_res(recipient_antibodies), \
         'This method is available just for antibodies in high res.'
 
@@ -179,7 +180,7 @@ def analyze_if_high_res_antibodies_are_type_a(
         if antibody.mfi < antibody.cutoff:
             is_some_antibody_below_cutoff = True
 
-    if not is_some_antibody_below_cutoff:
+    if not is_some_antibody_below_cutoff and strictness_type == StrictnessType.STRICT:
         return HighResAntibodiesAnalysis(False,
                                          ParsingIssueDetail.ALL_ANTIBODIES_ARE_POSITIVE_IN_HIGH_RES)
     elif is_some_antibody_below_cutoff and len(recipient_antibodies) < SUFFICIENT_NUMBER_OF_ANTIBODIES_IN_HIGH_RES:

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -10,7 +10,7 @@ from txmatching.patients.hla_model import HLAAntibodies, HLAAntibodyRaw
 from txmatching.patients.patient_parameters import PatientParameters
 from txmatching.patients.patient_types import DonorDbId, RecipientDbId
 from txmatching.utils.blood_groups import BloodGroup
-from txmatching.utils.enums import TxmEventState
+from txmatching.utils.enums import StrictnessType, TxmEventState
 from txmatching.utils.hla_system.hla_crossmatch import \
     is_positive_hla_crossmatch
 from txmatching.utils.hla_system.hla_transformations.parsing_issue_detail import (
@@ -137,6 +137,7 @@ class TxmEventBase:
     name: str
     default_config_id: Optional[int]
     state: TxmEventState
+    strictness_type: StrictnessType = StrictnessType.STRICT
 
 
 @dataclass(init=False)
@@ -149,8 +150,9 @@ class TxmEvent(TxmEventBase):
     # pylint: disable=too-many-arguments
     # I think it is reasonable to have multiple arguments here
     def __init__(self, db_id: int, name: str, default_config_id: Optional[int], state: TxmEventState,
-                 all_donors: List[Donor], all_recipients: List[Recipient]):
-        super().__init__(db_id=db_id, name=name, default_config_id=default_config_id, state=state)
+                 strictness_type: StrictnessType, all_donors: List[Donor], all_recipients: List[Recipient]):
+        super().__init__(db_id=db_id, name=name, default_config_id=default_config_id, state=state,
+                         strictness_type=strictness_type)
         self.all_donors = all_donors
         self.all_recipients = all_recipients
         (
@@ -195,7 +197,7 @@ def calculate_cpra_and_get_compatible_donors_for_recipient(txm_event: TxmEvent, 
             # crossmatch test is negative -> donor is compatible to recipient
             compatible_donors.add(donor.db_id)
 
-    return 1 - len(compatible_donors)/len(active_donors), compatible_donors
+    return 1 - len(compatible_donors) / len(active_donors), compatible_donors
 
 
 def _filter_patients_that_dont_have_parsing_errors_or_unconfirmed_warnings(

--- a/txmatching/patients/patient.py
+++ b/txmatching/patients/patient.py
@@ -137,7 +137,7 @@ class TxmEventBase:
     name: str
     default_config_id: Optional[int]
     state: TxmEventState
-    strictness_type: StrictnessType = StrictnessType.STRICT
+    strictness_type: Optional[StrictnessType] = StrictnessType.STRICT
 
 
 @dataclass(init=False)

--- a/txmatching/utils/enums.py
+++ b/txmatching/utils/enums.py
@@ -42,6 +42,16 @@ class Solver(str, Enum):
     ILPSolver = 'ILPSolver'
 
 
+class StrictnessType(str, Enum):
+    """
+    Enum representing the strictness of HLA parsing.
+    Strict = normal parsing, no exceptions being made.
+    Forgiving = some parsing errors and warnings are overlooked for the sake of including recipients in a matching.
+    """
+    STRICT = 'STRICT'
+    FORGIVING = 'FORGIVING'
+
+
 # pylint:enable=invalid-name
 
 HLA_GROUPS_PROPERTIES = {

--- a/txmatching/utils/export/export_txm_event.py
+++ b/txmatching/utils/export/export_txm_event.py
@@ -12,6 +12,7 @@ from txmatching.database.services.txm_event_service import \
     get_txm_event_complete
 from txmatching.patients.patient import Donor, TxmEvent
 from txmatching.utils.country_enum import Country
+from txmatching.utils.enums import StrictnessType
 
 
 def get_id_or_none(donor: Optional[Donor], txm_event: TxmEvent) -> Optional[str]:
@@ -25,7 +26,8 @@ def get_patients_upload_json_from_txm_event_for_country(
         txm_event_id: int,
         country_code: Country,
         txm_event_name: str,
-        donor_medical_ids: List[str] = None
+        donor_medical_ids: List[str] = None,
+        strictness_type: StrictnessType = StrictnessType.STRICT
 ) -> PatientUploadDTOIn:
     txm_event = get_txm_event_complete(txm_event_id, load_antibodies_raw=True)
     donors = [
@@ -79,5 +81,6 @@ def get_patients_upload_json_from_txm_event_for_country(
         txm_event_name=txm_event_name,
         donors=donors,
         recipients=recipients,
-        add_to_existing_patients=True
+        add_to_existing_patients=True,
+        strictness_type=strictness_type
     )

--- a/txmatching/utils/hla_system/hla_transformations/hla_transformations.py
+++ b/txmatching/utils/hla_system/hla_transformations/hla_transformations.py
@@ -26,10 +26,6 @@ logger = logging.getLogger(__name__)
 def parse_hla_raw_code_with_details(hla_raw_code: str,
                                     strictness_type: StrictnessType = StrictnessType.STRICT) -> HlaCodeProcessingResult:
     if hla_raw_code in PARSE_HIGH_RES_HLA_CODE_EXCEPTIONS:
-        # TODO
-        if strictness_type == StrictnessType.FORGIVING:
-            return process_parsing_result(hla_raw_code, PARSE_HIGH_RES_HLA_CODE_EXCEPTIONS[hla_raw_code],
-                                          ParsingIssueDetail.FORGIVING_HLA_PARSING)
         return process_parsing_result(hla_raw_code, PARSE_HIGH_RES_HLA_CODE_EXCEPTIONS[hla_raw_code],
                                       ParsingIssueDetail.HIGH_RES_WITH_ASSUMED_SPLIT_CODE,
                                       strictness_type=strictness_type)

--- a/txmatching/utils/hla_system/hla_transformations/parsing_issue_detail.py
+++ b/txmatching/utils/hla_system/hla_transformations/parsing_issue_detail.py
@@ -10,7 +10,8 @@ class ParsingIssueDetail(str, Enum):
     HIGH_RES_WITHOUT_SPLIT = 'High res can be converted to broad resolution but split resolution is unknown'
     HIGH_RES_WITH_LETTER = 'High res code has letter in the end. Such codes are not converted to split and broad.'
     HIGH_RES_WITH_ASSUMED_SPLIT_CODE = 'There is currently no information about the serological equivalent of an allele. ' \
-                               'The assumed serology code was taken by the first two digits of the allele name.'
+                                       'The assumed serology code was taken by the first two digits of the allele name.'
+    FORGIVING_HLA_PARSING = 'This code would not have been parsed normally, but forgiving parsing was set.'
 
     # returning no value (hla code)
     MULTIPLE_SPLITS_OR_BROADS_FOUND = 'Multiple splits or broad were found, unable to choose the right one.' \
@@ -45,7 +46,8 @@ class ParsingIssueDetail(str, Enum):
 OK_PROCESSING_RESULTS = {
     ParsingIssueDetail.SUCCESSFULLY_PARSED,
     ParsingIssueDetail.HIGH_RES_WITHOUT_SPLIT,
-    ParsingIssueDetail.HIGH_RES_WITH_LETTER
+    ParsingIssueDetail.HIGH_RES_WITH_LETTER,
+    ParsingIssueDetail.FORGIVING_HLA_PARSING
 }
 
 WARNING_PROCESSING_RESULTS = {

--- a/txmatching/utils/hla_system/hla_transformations/utils.py
+++ b/txmatching/utils/hla_system/hla_transformations/utils.py
@@ -93,6 +93,6 @@ def process_parsing_result(high_res: Optional[str],
                 split=split_or_broad_raw,
                 broad=split_or_broad_raw
             ),
-            detail if detail is not None else ParsingIssueDetail.SUCCESSFULLY_PARSED
+            detail if detail is not None else ParsingIssueDetail.FORGIVING_HLA_PARSING
         )
     return HlaCodeProcessingResult(None, detail if detail else ParsingIssueDetail.UNEXPECTED_SPLIT_RES_CODE)

--- a/txmatching/utils/hla_system/hla_transformations/utils.py
+++ b/txmatching/utils/hla_system/hla_transformations/utils.py
@@ -3,6 +3,7 @@ import re
 from typing import List, Optional
 
 from txmatching.patients.hla_code import HLACode
+from txmatching.utils.enums import StrictnessType
 from txmatching.utils.hla_system.hla_regexes import (
     B_SEROLOGICAL_CODE_WITH_W_REGEX, CW_SEROLOGICAL_CODE_WITHOUT_W_REGEX,
     DQ_DP_SEROLOGICAL_CODE_WITH_AB_REGEX)
@@ -49,7 +50,8 @@ def _cleanup_split_or_broad_code(serological_hla_code: str) -> str:
 
 def process_parsing_result(high_res: Optional[str],
                            split_or_broad_raw: Optional[str],
-                           detail: Optional[ParsingIssueDetail] = None) -> HlaCodeProcessingResult:
+                           detail: Optional[ParsingIssueDetail] = None,
+                           strictness_type: StrictnessType = StrictnessType.STRICT) -> HlaCodeProcessingResult:
     if split_or_broad_raw is None:
         assert detail is not None
         return HlaCodeProcessingResult(
@@ -84,4 +86,13 @@ def process_parsing_result(high_res: Optional[str],
         )
     if split_or_broad_raw in IRRELEVANT_CODES:
         return HlaCodeProcessingResult(None, detail if detail else ParsingIssueDetail.IRRELEVANT_CODE)
+    if strictness_type == StrictnessType.FORGIVING:
+        return HlaCodeProcessingResult(
+            HLACode(
+                high_res=None,
+                split=split_or_broad_raw,
+                broad=split_or_broad_raw
+            ),
+            detail if detail is not None else ParsingIssueDetail.SUCCESSFULLY_PARSED
+        )
     return HlaCodeProcessingResult(None, detail if detail else ParsingIssueDetail.UNEXPECTED_SPLIT_RES_CODE)

--- a/txmatching/web/api/matching_api.py
+++ b/txmatching/web/api/matching_api.py
@@ -49,9 +49,9 @@ class CalculateFromConfig(Resource):
                                                                    configuration.id)
         configuration_parameters = configuration.parameters
         calculated_matchings_dto.calculated_matchings = calculated_matchings_dto.calculated_matchings[
-            :configuration_parameters.max_number_of_matchings]
+                                                        :configuration_parameters.max_number_of_matchings]
         if get_user_role() == UserRole.VIEWER:
             calculated_matchings_dto.calculated_matchings = calculated_matchings_dto.calculated_matchings[
-                :configuration_parameters.max_matchings_to_show_to_viewer]
+                                                            :configuration_parameters.max_matchings_to_show_to_viewer]
         logging.debug('Collected matchings and sending them')
         return response_ok(calculated_matchings_dto)

--- a/txmatching/web/api/txm_event_api.py
+++ b/txmatching/web/api/txm_event_api.py
@@ -156,7 +156,8 @@ class TxmExportEventApi(Resource):
         txm_event_json = get_patients_upload_json_from_txm_event_for_country(
             txm_event_id=txm_event_id,
             country_code=export_dto.country,
-            txm_event_name=export_dto.new_txm_event_name
+            txm_event_name=export_dto.new_txm_event_name,
+            strictness_type=export_dto.strictness_type
         )
         return response_ok(txm_event_json)
 

--- a/txmatching/web/api/txm_event_api.py
+++ b/txmatching/web/api/txm_event_api.py
@@ -43,8 +43,8 @@ class TxmEventApi(Resource):
     @txm_event_api.response_errors(exceptions={NonUniquePatient}, add_default_namespace_errors=True)
     @require_role(UserRole.ADMIN)
     def post(self):
-        tmx_event = request_body(TxmEventDTOIn)
-        created_event = create_txm_event(tmx_event.name)
+        txm_event = request_body(TxmEventDTOIn)
+        created_event = create_txm_event(txm_event.name, txm_event.strictness_type)
         return response_ok(
             convert_txm_event_base_to_dto(created_event),
             code=201)
@@ -89,6 +89,7 @@ class TxmDefaultEventApi(Resource):
     def get(self) -> str:
         txm_event = get_txm_event_base(get_txm_event_id_for_current_user())
         return response_ok(convert_txm_event_base_to_dto(txm_event))
+
 
 # noinspection PyUnresolvedReferences
 

--- a/txmatching/web/frontend/src/app/components/header/header.component.html
+++ b/txmatching/web/frontend/src/app/components/header/header.component.html
@@ -10,7 +10,7 @@
           <div class="name">
             {{ defaultTxmEvent.name }}
             <div
-              *ngIf="defaultTxmEvent.state === txmEventState.Closed"
+              *ngIf="defaultTxmEvent.state === txmEventState.CLOSED"
               class="label-closed"
               matTooltip="This TXM event is closed and patients and default configuration cannot be modified"
             >
@@ -34,7 +34,7 @@
               [selected]="defaultTxmEvent.id === txmEvent.id"
             >
               {{ txmEvent.name }}
-              <strong *ngIf="txmEvent.state === txmEventState.Closed"> (closed) </strong>
+              <strong *ngIf="txmEvent.state === txmEventState.CLOSED"> (closed) </strong>
             </mat-list-option>
           </mat-selection-list>
         </app-dropdown>

--- a/txmatching/web/frontend/src/app/components/header/header.component.ts
+++ b/txmatching/web/frontend/src/app/components/header/header.component.ts
@@ -5,7 +5,7 @@ import { AuthService } from "@app/services/auth/auth.service";
 import { UploadDownloadStatus } from "@app/components/header/header.interface";
 import { TxmEvent, TxmEvents } from "@app/model/Event";
 import { MatSelectionListChange } from "@angular/material/list";
-import { TxmEventStateGenerated } from "@app/generated";
+import { TxmEventStateType } from "@app/model/enums/TxmEventStateType";
 
 @Component({
   selector: "app-header",
@@ -34,7 +34,7 @@ export class HeaderComponent {
   public infoIcon = faQuestionCircle;
 
   public uploadDownloadStatus: typeof UploadDownloadStatus = UploadDownloadStatus;
-  public txmEventState: typeof TxmEventStateGenerated = TxmEventStateGenerated;
+  public txmEventState: typeof TxmEventStateType = TxmEventStateType;
 
   constructor(private _authService: AuthService) {}
 

--- a/txmatching/web/frontend/src/app/generated/model/models.ts
+++ b/txmatching/web/frontend/src/app/generated/model/models.ts
@@ -69,6 +69,7 @@ export * from './serviceStatusGenerated';
 export * from './sexEnumGenerated';
 export * from './solverGenerated';
 export * from './statisticsGenerated';
+export * from './strictnessTypeGenerated';
 export * from './successGenerated';
 export * from './transplantGenerated';
 export * from './transplantWarningGenerated';

--- a/txmatching/web/frontend/src/app/generated/model/parsingIssuePublicGenerated.ts
+++ b/txmatching/web/frontend/src/app/generated/model/parsingIssuePublicGenerated.ts
@@ -22,6 +22,8 @@ export enum ParsingIssuePublicGeneratedParsingIssueDetailEnum {
     SuccessfullyParsed = 'SUCCESSFULLY_PARSED',
     HighResWithoutSplit = 'HIGH_RES_WITHOUT_SPLIT',
     HighResWithLetter = 'HIGH_RES_WITH_LETTER',
+    HighResWithAssumedSplitCode = 'HIGH_RES_WITH_ASSUMED_SPLIT_CODE',
+    ForgivingHlaParsing = 'FORGIVING_HLA_PARSING',
     MultipleSplitsOrBroadsFound = 'MULTIPLE_SPLITS_OR_BROADS_FOUND',
     IrrelevantCode = 'IRRELEVANT_CODE',
     UnexpectedSplitResCode = 'UNEXPECTED_SPLIT_RES_CODE',

--- a/txmatching/web/frontend/src/app/generated/model/strictnessTypeGenerated.ts
+++ b/txmatching/web/frontend/src/app/generated/model/strictnessTypeGenerated.ts
@@ -9,11 +9,13 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { StrictnessTypeGenerated } from './strictnessTypeGenerated';
 
 
-export interface NewTxmEventGenerated { 
-    name: string;
-    strictness_type?: StrictnessTypeGenerated;
-}
+/**
+ * Level of strictness for HLA parsing.
+ */
+export enum StrictnessTypeGenerated {
+    Strict = 'STRICT',
+    Forgiving = 'FORGIVING'
+};
 

--- a/txmatching/web/frontend/src/app/generated/model/txmEventExportGenerated.ts
+++ b/txmatching/web/frontend/src/app/generated/model/txmEventExportGenerated.ts
@@ -10,10 +10,12 @@
  * Do not edit the class manually.
  */
 import { CountryCodeGenerated } from './countryCodeGenerated';
+import { StrictnessTypeGenerated } from './strictnessTypeGenerated';
 
 
 export interface TxmEventExportGenerated { 
     country: CountryCodeGenerated;
     new_txm_event_name: string;
+    strictness_type?: StrictnessTypeGenerated;
 }
 

--- a/txmatching/web/frontend/src/app/generated/model/txmEventGenerated.ts
+++ b/txmatching/web/frontend/src/app/generated/model/txmEventGenerated.ts
@@ -9,6 +9,7 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { StrictnessTypeGenerated } from './strictnessTypeGenerated';
 import { TxmEventStateGenerated } from './txmEventStateGenerated';
 
 
@@ -17,5 +18,6 @@ export interface TxmEventGenerated {
     id: number;
     name: string;
     state: TxmEventStateGenerated;
+    strictness_type: StrictnessTypeGenerated;
 }
 

--- a/txmatching/web/frontend/src/app/generated/model/uploadPatientsGenerated.ts
+++ b/txmatching/web/frontend/src/app/generated/model/uploadPatientsGenerated.ts
@@ -12,6 +12,7 @@
 import { RecipientInputGenerated } from './recipientInputGenerated';
 import { CountryCodeGenerated } from './countryCodeGenerated';
 import { DonorInputGenerated } from './donorInputGenerated';
+import { StrictnessTypeGenerated } from './strictnessTypeGenerated';
 
 
 export interface UploadPatientsGenerated { 
@@ -22,6 +23,7 @@ export interface UploadPatientsGenerated {
     country: CountryCodeGenerated;
     donors: Array<DonorInputGenerated>;
     recipients: Array<RecipientInputGenerated>;
+    strictness_type?: StrictnessTypeGenerated;
     /**
      * The TXM event name has to be provided by an ADMIN.
      */

--- a/txmatching/web/frontend/src/app/model/Event.ts
+++ b/txmatching/web/frontend/src/app/model/Event.ts
@@ -1,10 +1,11 @@
-import { TxmEventStateGenerated } from "@app/generated";
+import { TxmEventStateGenerated, StrictnessTypeGenerated } from '@app/generated';
 
 export interface TxmEvent {
   id: number;
   name: string;
   defaultConfigId?: number;
   state: TxmEventStateGenerated;
+  strictness_type: StrictnessTypeGenerated;
 }
 
 export interface TxmEvents {

--- a/txmatching/web/frontend/src/app/model/Event.ts
+++ b/txmatching/web/frontend/src/app/model/Event.ts
@@ -1,11 +1,12 @@
-import { TxmEventStateGenerated, StrictnessTypeGenerated } from '@app/generated';
+import { StrictnessType } from "@app/model/enums/StrictnessType";
+import { TxmEventStateType } from "@app/model/enums/TxmEventStateType";
 
 export interface TxmEvent {
   id: number;
   name: string;
   defaultConfigId?: number;
-  state: TxmEventStateGenerated;
-  strictness_type: StrictnessTypeGenerated;
+  state: TxmEventStateType;
+  strictnessType: StrictnessType;
 }
 
 export interface TxmEvents {

--- a/txmatching/web/frontend/src/app/model/enums/StrictnessType.ts
+++ b/txmatching/web/frontend/src/app/model/enums/StrictnessType.ts
@@ -1,0 +1,4 @@
+export enum StrictnessType {
+  STRICT = "STRICT",
+  FORGIVING = "FORGIVING",
+}

--- a/txmatching/web/frontend/src/app/model/enums/TxmEventStateType.ts
+++ b/txmatching/web/frontend/src/app/model/enums/TxmEventStateType.ts
@@ -1,0 +1,4 @@
+export enum TxmEventStateType {
+  OPEN = "OPEN",
+  CLOSED = "CLOSED",
+}

--- a/txmatching/web/frontend/src/app/pages/home/home.component.ts
+++ b/txmatching/web/frontend/src/app/pages/home/home.component.ts
@@ -14,10 +14,10 @@ import { Report } from "@app/services/report/report.interface";
 import { finalize, first } from "rxjs/operators";
 import { EventService } from "@app/services/event/event.service";
 import { AbstractLoggedComponent } from "@app/pages/abstract-logged/abstract-logged.component";
-import { TxmEventStateGenerated } from "@app/generated";
 import { TemplatePopupStyle } from "@app/components/template-popup/template-popup.interface";
 import { ReportConfig } from "@app/components/generate-report/generate-report.interface";
 import { getErrorMessage } from "@app/helpers/error";
+import { TxmEventStateType } from "@app/model/enums/TxmEventStateType";
 
 @Component({
   selector: "app-home",
@@ -109,7 +109,7 @@ export class HomeComponent extends AbstractLoggedComponent implements OnInit, On
   }
 
   get canSetDefaultConfig(): boolean {
-    const txmEventOpen = this.defaultTxmEvent?.state === TxmEventStateGenerated.Open;
+    const txmEventOpen = this.defaultTxmEvent?.state === TxmEventStateType.OPEN;
     const configIdDefined = !!this._eventService.getConfigId();
     return txmEventOpen && configIdDefined;
   }

--- a/txmatching/web/frontend/src/app/pages/patients/patients.component.ts
+++ b/txmatching/web/frontend/src/app/pages/patients/patients.component.ts
@@ -5,7 +5,6 @@ import { AlertService } from "@app/services/alert/alert.service";
 import { AuthService } from "@app/services/auth/auth.service";
 import { UploadDownloadStatus } from "@app/components/header/header.interface";
 import { ConfigurationService } from "@app/services/configuration/configuration.service";
-import { PatientList } from "@app/model/PatientList";
 import { PatientPair } from "@app/model/PatientPair";
 import { Donor } from "@app/model/Donor";
 import { PatientPairItemComponent } from "@app/components/patient-pair-item/patient-pair-item.component";
@@ -15,12 +14,12 @@ import { PatientDonorDetailWrapperComponent } from "@app/components/patient-dono
 import { EventService } from "@app/services/event/event.service";
 import { AbstractLoggedComponent } from "@app/pages/abstract-logged/abstract-logged.component";
 import { Subscription } from "rxjs";
-import { TxmEventStateGenerated } from "@app/generated";
 import { PatientPairToAdd } from "@app/services/patient/patient.service.interface";
 import { DonorType } from "@app/model/enums/DonorType";
 import { ReportService } from "@app/services/report/report.service";
 import { getErrorMessage } from "@app/helpers/error";
 import { ParsingIssuePublic } from "@app/model/ParsingIssuePublic";
+import { TxmEventStateType } from "@app/model/enums/TxmEventStateType";
 
 @Component({
   selector: "app-patients",
@@ -207,6 +206,6 @@ export class PatientsComponent extends AbstractLoggedComponent implements OnDest
   }
 
   get canModifyPatients(): boolean {
-    return this.defaultTxmEvent?.state === TxmEventStateGenerated.Open;
+    return this.defaultTxmEvent?.state === TxmEventStateType.OPEN;
   }
 }

--- a/txmatching/web/frontend/src/app/parsers/event.parsers.ts
+++ b/txmatching/web/frontend/src/app/parsers/event.parsers.ts
@@ -1,19 +1,28 @@
-import { TxmEventGenerated, TxmEventsGenerated } from '../generated';
-import { TxmEvent, TxmEvents } from '../model/Event';
+import { TxmEventStateType } from "@app/model/enums/TxmEventStateType";
+import { StrictnessTypeGenerated, TxmEventGenerated, TxmEventsGenerated, TxmEventStateGenerated } from "../generated";
+import { TxmEvent, TxmEvents } from "../model/Event";
+import { StrictnessType } from "@app/model/enums/StrictnessType";
 
 export const parseTxmEvent = (data: TxmEventGenerated): TxmEvent => {
   return {
     id: data.id,
     name: data.name,
     defaultConfigId: data.default_config_id,
-    state: data.state,
-    // TODO change this
-    strictness_type: data.strictness_type
+    state: parseTxmEventState(data.state),
+    strictnessType: parseStrictnessType(data.strictness_type),
   };
 };
 
 export const parseTxmEvents = (data: TxmEventsGenerated): TxmEvents => {
   return {
-    events: data.events.map(parseTxmEvent)
+    events: data.events.map(parseTxmEvent),
   };
+};
+
+export const parseTxmEventState = (data: TxmEventStateGenerated): TxmEventStateType => {
+  return TxmEventStateType[data];
+};
+
+export const parseStrictnessType = (data: StrictnessTypeGenerated): StrictnessType => {
+  return StrictnessType[data];
 };

--- a/txmatching/web/frontend/src/app/parsers/event.parsers.ts
+++ b/txmatching/web/frontend/src/app/parsers/event.parsers.ts
@@ -1,5 +1,5 @@
-import { TxmEventGenerated, TxmEventsGenerated } from "../generated";
-import { TxmEvent, TxmEvents } from "../model/Event";
+import { TxmEventGenerated, TxmEventsGenerated } from '../generated';
+import { TxmEvent, TxmEvents } from '../model/Event';
 
 export const parseTxmEvent = (data: TxmEventGenerated): TxmEvent => {
   return {
@@ -7,11 +7,13 @@ export const parseTxmEvent = (data: TxmEventGenerated): TxmEvent => {
     name: data.name,
     defaultConfigId: data.default_config_id,
     state: data.state,
+    // TODO change this
+    strictness_type: data.strictness_type
   };
 };
 
 export const parseTxmEvents = (data: TxmEventsGenerated): TxmEvents => {
   return {
-    events: data.events.map(parseTxmEvent),
+    events: data.events.map(parseTxmEvent)
   };
 };

--- a/txmatching/web/frontend/src/app/services/event/event.service.ts
+++ b/txmatching/web/frontend/src/app/services/event/event.service.ts
@@ -44,7 +44,7 @@ export class EventService {
   public async getDefaultEvent(): Promise<TxmEvent> {
     if (!this._defaultTxmEvent) {
       this._defaultTxmEvent = firstValueFrom(
-        this._http.get<TxmEvent>(`${environment.apiUrl}/txm-event/default`).pipe(map(parseTxmEvent))
+        this._http.get<TxmEventGenerated>(`${environment.apiUrl}/txm-event/default`).pipe(map(parseTxmEvent))
       );
     }
     return this._defaultTxmEvent;

--- a/txmatching/web/swagger/swagger.json
+++ b/txmatching/web/swagger/swagger.json
@@ -4682,6 +4682,9 @@
                 },
                 "new_txm_event_name": {
                     "type": "string"
+                },
+                "strictness_type": {
+                    "$ref": "#/definitions/StrictnessType"
                 }
             },
             "type": "object"
@@ -4783,6 +4786,9 @@
                     "type": "boolean",
                     "description": "If *true* the currently uploaded patients will be added to the patients already in the system. If *false* the data in the system will be overwritten by the currently uploaded data.",
                     "default": false
+                },
+                "strictness_type": {
+                    "$ref": "#/definitions/StrictnessType"
                 }
             },
             "type": "object"

--- a/txmatching/web/swagger/swagger.json
+++ b/txmatching/web/swagger/swagger.json
@@ -3653,6 +3653,9 @@
             "properties": {
                 "name": {
                     "type": "string"
+                },
+                "strictness_type": {
+                    "$ref": "#/definitions/StrictnessType"
                 }
             },
             "type": "object"
@@ -3830,6 +3833,7 @@
                         "HIGH_RES_WITHOUT_SPLIT",
                         "HIGH_RES_WITH_LETTER",
                         "HIGH_RES_WITH_ASSUMED_SPLIT_CODE",
+                        "FORGIVING_HLA_PARSING",
                         "MULTIPLE_SPLITS_OR_BROADS_FOUND",
                         "IRRELEVANT_CODE",
                         "UNEXPECTED_SPLIT_RES_CODE",
@@ -4448,6 +4452,14 @@
             },
             "type": "object"
         },
+        "StrictnessType": {
+            "enum": [
+                "STRICT",
+                "FORGIVING"
+            ],
+            "type": "string",
+            "description": "Level of strictness for HLA parsing."
+        },
         "Success": {
             "required": [
                 "success"
@@ -4615,7 +4627,8 @@
             "required": [
                 "id",
                 "name",
-                "state"
+                "state",
+                "strictness_type"
             ],
             "properties": {
                 "id": {
@@ -4629,6 +4642,9 @@
                 },
                 "state": {
                     "$ref": "#/definitions/TxmEventState"
+                },
+                "strictness_type": {
+                    "$ref": "#/definitions/StrictnessType"
                 }
             },
             "type": "object"

--- a/txmatching/web/swagger/swagger.yaml
+++ b/txmatching/web/swagger/swagger.yaml
@@ -1120,6 +1120,8 @@ definitions:
         properties:
             name:
                 type: string
+            strictness_type:
+                $ref: '#/definitions/StrictnessType'
         required:
         - name
         type: object
@@ -1236,6 +1238,7 @@ definitions:
                 - HIGH_RES_WITHOUT_SPLIT
                 - HIGH_RES_WITH_LETTER
                 - HIGH_RES_WITH_ASSUMED_SPLIT_CODE
+                - FORGIVING_HLA_PARSING
                 - MULTIPLE_SPLITS_OR_BROADS_FOUND
                 - IRRELEVANT_CODE
                 - UNEXPECTED_SPLIT_RES_CODE
@@ -1605,6 +1608,12 @@ definitions:
         - number_of_found_cycles_and_chains
         - number_of_found_transplants
         type: object
+    StrictnessType:
+        description: Level of strictness for HLA parsing.
+        enum:
+        - STRICT
+        - FORGIVING
+        type: string
     Success:
         properties:
             success:
@@ -1660,10 +1669,13 @@ definitions:
                 type: string
             state:
                 $ref: '#/definitions/TxmEventState'
+            strictness_type:
+                $ref: '#/definitions/StrictnessType'
         required:
         - id
         - name
         - state
+        - strictness_type
         type: object
     TxmEventCopy:
         properties:

--- a/txmatching/web/swagger/swagger.yaml
+++ b/txmatching/web/swagger/swagger.yaml
@@ -1698,6 +1698,8 @@ definitions:
                 $ref: '#/definitions/CountryCode'
             new_txm_event_name:
                 type: string
+            strictness_type:
+                $ref: '#/definitions/StrictnessType'
         required:
         - country
         - new_txm_event_name
@@ -1763,6 +1765,8 @@ definitions:
                 items:
                     $ref: '#/definitions/RecipientInput'
                 type: array
+            strictness_type:
+                $ref: '#/definitions/StrictnessType'
             txm_event_name:
                 description: The TXM event name has to be provided by an ADMIN.
                 example: 2020-10-example_event

--- a/txmatching/web/swagger/swagger_public.json
+++ b/txmatching/web/swagger/swagger_public.json
@@ -1298,6 +1298,7 @@
                         "HIGH_RES_WITHOUT_SPLIT",
                         "HIGH_RES_WITH_LETTER",
                         "HIGH_RES_WITH_ASSUMED_SPLIT_CODE",
+                        "FORGIVING_HLA_PARSING",
                         "MULTIPLE_SPLITS_OR_BROADS_FOUND",
                         "IRRELEVANT_CODE",
                         "UNEXPECTED_SPLIT_RES_CODE",

--- a/txmatching/web/swagger/swagger_public.json
+++ b/txmatching/web/swagger/swagger_public.json
@@ -1535,6 +1535,14 @@
             },
             "type": "object"
         },
+        "StrictnessType": {
+            "enum": [
+                "STRICT",
+                "FORGIVING"
+            ],
+            "type": "string",
+            "description": "Level of strictness for HLA parsing."
+        },
         "Success": {
             "required": [
                 "success"
@@ -1578,6 +1586,9 @@
                     "type": "boolean",
                     "description": "If *true* the currently uploaded patients will be added to the patients already in the system. If *false* the data in the system will be overwritten by the currently uploaded data.",
                     "default": false
+                },
+                "strictness_type": {
+                    "$ref": "#/definitions/StrictnessType"
                 }
             },
             "type": "object"


### PR DESCRIPTION
Alternativne HLA parsovanie pre spanielske data - riesila som errory aj warningy, lebo tych warningov bolo napr aj 100 pre niektorych recipientov.

je to tak ze:
STRICT = normalne parsovanie ako doteraz
FORGIVING = prizmurujem oko tam kde to bolo treba

zmenila som `assertEquals` na `assertEqual`, lebo to prve uz je deprecated